### PR TITLE
Force signup before checkout

### DIFF
--- a/app/(auth)/signup/[[...signup]]/page.tsx
+++ b/app/(auth)/signup/[[...signup]]/page.tsx
@@ -7,13 +7,16 @@ This client page provides the signup form from Clerk.
 import { SignUp } from "@clerk/nextjs"
 import { dark } from "@clerk/themes"
 import { useTheme } from "next-themes"
+import { useSearchParams } from "next/navigation"
 
 export default function SignUpPage() {
   const { theme } = useTheme()
+  const searchParams = useSearchParams()
+  const redirectUrl = searchParams.get("redirect_url") || "/"
 
   return (
     <SignUp
-      forceRedirectUrl="/"
+      forceRedirectUrl={redirectUrl}
       appearance={{ baseTheme: theme === "dark" ? dark : undefined }}
     />
   )

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -111,7 +111,9 @@ function PricingCard({
 }: PricingCardProps) {
   const finalButtonLink = userId
     ? `${buttonLink}?client_reference_id=${userId}`
-    : buttonLink
+    : `/signup?redirect_url=${encodeURIComponent(
+        `/checkout?payment_link=${encodeURIComponent(buttonLink)}`
+      )}`
 
   return (
     <Card

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,0 +1,17 @@
+"use server"
+
+import { auth } from "@clerk/nextjs/server"
+import { redirect } from "next/navigation"
+
+export default async function CheckoutRedirect({ searchParams }: { searchParams: { payment_link?: string } }) {
+  const paymentLink = searchParams.payment_link
+  if (!paymentLink) {
+    redirect("/")
+  }
+
+  const { userId } = await auth()
+  const url = userId
+    ? `${paymentLink}?client_reference_id=${userId}`
+    : paymentLink
+  redirect(url)
+}

--- a/components/landing/pricing-section.tsx
+++ b/components/landing/pricing-section.tsx
@@ -42,7 +42,9 @@ const PricingCard = ({
 }: PricingCardProps) => {
   const finalButtonLink = userId
     ? `${buttonLink}?client_reference_id=${userId}`
-    : buttonLink
+    : `/signup?redirect_url=${encodeURIComponent(
+        `/checkout?payment_link=${encodeURIComponent(buttonLink)}`
+      )}`
 
   return (
     <motion.div


### PR DESCRIPTION
## Summary
- redirect marketing pricing buttons to signup when user isn't logged in
- allow signup page to read a redirect URL and send user there when complete
- add server page to forward to Stripe checkout with user ID

## Testing
- `npm run lint`
- `npm run type-check`
