### PR TITLE
Add shared marketing layout components

### DIFF
--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -4,7 +4,8 @@ This server layout provides a shared header and basic structure for (marketing) 
 
 "use server"
 
-import Header from "@/components/landing/header"
+import Header from "@/components/Header"
+import Footer from "@/components/Footer"
 
 export default async function MarketingLayout({
   children
@@ -12,9 +13,10 @@ export default async function MarketingLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col bg-[var(--color-bg)] text-[var(--color-text)]">
       <Header />
-      <div className="flex-1">{children}</div>
+      <main className="flex-1">{children}</main>
+      <Footer />
     </div>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,7 @@ import { auth } from "@clerk/nextjs/server"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css"
+import "../styles/tokens.css"
 
 const inter = Inter({ subsets: ["latin"] })
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link"
+import { Logo } from "@/components/logo"
+
+export default function Footer() {
+  return (
+    <footer className="bg-[#111827] py-12 text-[rgba(255,255,255,.8)]">
+      <div className="mx-auto grid w-full max-w-[1280px] gap-8 px-4 md:grid-cols-3">
+        <div>
+          <Logo className="h-8 w-auto text-white" />
+          <p className="mt-4 text-sm">
+            APSPitchPro helps you craft the perfect pitch for APS roles.
+          </p>
+        </div>
+        <div>
+          <h4 className="text-white">Quick Links</h4>
+          <ul className="mt-4 space-y-2">
+            <li>
+              <Link
+                href="#features"
+                className="hover:text-[var(--color-primary)]"
+              >
+                Features
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="#pricing"
+                className="hover:text-[var(--color-primary)]"
+              >
+                Pricing
+              </Link>
+            </li>
+            <li>
+              <Link href="#faq" className="hover:text-[var(--color-primary)]">
+                FAQ
+              </Link>
+            </li>
+          </ul>
+        </div>
+        <div className="space-y-2">
+          <h4 className="text-white">Legal</h4>
+          <p className="text-sm">© {new Date().getFullYear()} APSPitchPro</p>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,53 @@
+"use client"
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { Logo } from "@/components/logo"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+const navLinks = [
+  { href: "#features", label: "Features" },
+  { href: "#pricing", label: "Pricing" },
+  { href: "#faq", label: "FAQ" }
+]
+
+export default function Header() {
+  const [scrolled, setScrolled] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 64)
+    window.addEventListener("scroll", onScroll)
+    return () => window.removeEventListener("scroll", onScroll)
+  }, [])
+
+  return (
+    <header
+      className={cn(
+        "sticky top-0 z-50 w-full border-b border-[#E5E7EB] bg-[#FFFFFF]",
+        "transition-shadow",
+        scrolled && "shadow-[0_1px_6px_rgba(0,0,0,.06)]"
+      )}
+      style={{ height: "4.5rem" }}
+    >
+      <div className="mx-auto flex h-full w-full max-w-[1280px] items-center justify-between px-4">
+        <Link href="/" className="flex items-center gap-2">
+          <Logo className="h-12 w-auto" />
+        </Link>
+        <nav className="hidden gap-4 md:flex">
+          {navLinks.map(link => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="text-sm font-medium text-[color:var(--color-text)] hover:text-[color:var(--color-primary)]"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+        <Button className="h-9 px-4 font-semibold text-white bg-[var(--color-primary)] hover:bg-[var(--color-primary-hover)]">
+          Get Started Free
+        </Button>
+      </div>
+    </header>
+  )
+}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,10 @@
+:root {
+  --color-primary: #0057b7;
+  --color-primary-hover: #00479b;
+  --color-bg: #ffffff;
+  --color-text: #111827;
+  --color-subtle: #4b5563;
+  --radius: 0.75rem;
+  --shadow-card: 0 4px 24px rgba(17, 24, 39, 0.08);
+  --font-sans: "Inter", "Helvetica Neue", Arial, sans-serif;
+}


### PR DESCRIPTION
## Summary
- create design tokens file
- add Header and Footer components
- use Header and Footer in marketing layout
- load tokens in root layout

## Testing
- `npx prettier --write components/Header.tsx components/Footer.tsx "app/(marketing)/layout.tsx" app/layout.tsx styles/tokens.css`
- `npm run lint`