### PR TITLE
Fix completed filter and add pitch export

### DIFF
--- a/app/(dashboard)/dashboard/_components/dashboard-sidebar.tsx
+++ b/app/(dashboard)/dashboard/_components/dashboard-sidebar.tsx
@@ -24,7 +24,6 @@
 
 import Link from "next/link"
 import { Settings } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
 import { getProfileByUserIdAction } from "@/actions/db/profiles-actions"
 
 /**
@@ -49,17 +48,11 @@ export default async function DashboardSidebar({
   const profileResult = await getProfileByUserIdAction(userId)
   const hasStripeCustomerId =
     profileResult.isSuccess && profileResult.data?.stripeCustomerId
-  const credits = profileResult.isSuccess
-    ? (profileResult.data?.credits ?? 0)
-    : 0
 
   return (
     <div className="w-64 flex-shrink-0 border-r bg-white shadow-sm">
       <div className="p-5 border-b space-y-2">
         <h1 className="text-xl font-bold text-gray-800">Pitch Manager</h1>
-        <Badge variant="secondary" className="text-xs">
-          {credits} credits remaining
-        </Badge>
       </div>
 
       <nav className="p-3 space-y-1">

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -25,6 +25,7 @@
 
 import { auth } from "@clerk/nextjs/server"
 import { getAllPitchesForUserAction } from "@/actions/db/pitches-actions"
+import { getProfileByUserIdAction } from "@/actions/db/profiles-actions"
 import { Suspense } from "react"
 import PitchTable from "@/app/(dashboard)/dashboard/_components/pitch-table"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -51,7 +52,7 @@ function PitchTableSkeleton() {
           <Skeleton className="h-6 w-20" />
           <Skeleton className="h-6 w-20" />
         </div>
-        {[1, 2, 3, 4].map((i) => (
+        {[1, 2, 3, 4].map(i => (
           <div key={i} className="grid grid-cols-4 gap-4 p-4 border-b">
             <Skeleton className="h-6 w-full" />
             <Skeleton className="h-6 w-full" />
@@ -69,7 +70,7 @@ function PitchTableSkeleton() {
  */
 async function PitchTableFetcher() {
   const { userId } = await auth()
-  
+
   // This should never happen since the layout already checks for auth,
   // but we handle it for type safety
   if (!userId) {
@@ -80,9 +81,10 @@ async function PitchTableFetcher() {
       </div>
     )
   }
-  
-  // Fetch all pitches for this user
+
+  // Fetch all pitches and profile for this user
   const pitchesRes = await getAllPitchesForUserAction(userId)
+  const profileRes = await getProfileByUserIdAction(userId)
 
   // If the DB action fails, display an error
   if (!pitchesRes.isSuccess) {
@@ -94,7 +96,8 @@ async function PitchTableFetcher() {
     )
   }
 
-  return <PitchTable pitches={pitchesRes.data} />
+  const credits = profileRes.isSuccess ? (profileRes.data?.credits ?? 0) : 0
+  return <PitchTable pitches={pitchesRes.data} credits={credits} />
 }
 
 /**


### PR DESCRIPTION
## Summary
- show credits count under the Create Pitch button instead of sidebar
- fix Completed status filtering on dashboard
- allow exporting pitches to PDF or Word
- fetch profile credits for dashboard page

## Testing
- `npm run lint`
- `npm run type-check`
