### PR TITLE
Improve pitch wizard responsiveness

### DIFF
--- a/app/(wizard)/dashboard/new/_components/pitch-wizard/index.tsx
+++ b/app/(wizard)/dashboard/new/_components/pitch-wizard/index.tsx
@@ -1,3 +1,4 @@
+// Handles the multi-step pitch creation wizard and navigation controls
 "use client"
 
 import { FormProvider } from "react-hook-form"
@@ -88,7 +89,7 @@ export default function PitchWizard({ userId, pitchData }: PitchWizardProps) {
   // Return the entire form + wizard controls
   return (
     <FormProvider {...methods}>
-      <div className="space-y-8">
+      <div className="space-y-6 max-w-full">
         {/* Add global styles for form fields */}
         <style jsx global>{`
           .space-y-8 input, 
@@ -122,10 +123,10 @@ export default function PitchWizard({ userId, pitchData }: PitchWizardProps) {
         </div>
 
         {/* Card containing form fields */}
-        <div 
-          className="bg-white rounded-2xl overflow-hidden mb-8"
-          style={{ 
-            boxShadow: '0 12px 28px -12px rgba(0, 0, 0, 0.07), 0 5px 12px -6px rgba(0, 0, 0, 0.035)' 
+        <div
+          className="bg-white rounded-2xl overflow-hidden"
+          style={{
+            boxShadow: '0 12px 28px -12px rgba(0, 0, 0, 0.07), 0 5px 12px -6px rgba(0, 0, 0, 0.035)'
           }}
         >
           <motion.div
@@ -140,7 +141,7 @@ export default function PitchWizard({ userId, pitchData }: PitchWizardProps) {
         </div>
 
         {/* Navigation buttons */}
-        <div className="pt-10 flex justify-between items-center mt-10">
+        <div className="pt-6 flex flex-col sm:flex-row justify-between items-center gap-4">
           {/* Back button - only show when not on the review step */}
           {currentStep > 1 && currentStep < totalSteps ? (
             <Button 

--- a/app/(wizard)/dashboard/new/_components/section-progress-bar.tsx
+++ b/app/(wizard)/dashboard/new/_components/section-progress-bar.tsx
@@ -3,6 +3,7 @@
 
 import { Section } from "@/types"
 import clsx from "clsx"
+import { useState } from "react"
 
 interface SectionProgressSidebarProps {
   current?: Section
@@ -35,8 +36,18 @@ export default function SectionProgressSidebar({
   onNavigate,
   className,
 }: SectionProgressSidebarProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
   return (
-    <div className="w-full space-y-6">
+    <div className={clsx("w-full", className)}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((o) => !o)}
+        className="lg:hidden mb-4 px-3 py-2 border rounded-md text-sm"
+      >
+        {isOpen ? "Hide Steps" : "Show Steps"}
+      </button>
+      <div className={clsx(isOpen ? "block" : "hidden", "space-y-6 lg:block")}>
       {STEP_ORDER.map((step, idx) => {
         // Check if step is completed based on maxCompleted, not current
         const isCompleted = STEP_ORDER.indexOf(step) < STEP_ORDER.indexOf(maxCompleted) || step === maxCompleted;
@@ -87,6 +98,7 @@ export default function SectionProgressSidebar({
           </button>
         )
       })}
+      </div>
     </div>
   )
 }

--- a/app/(wizard)/dashboard/new/_components/wizard-intro-step.tsx
+++ b/app/(wizard)/dashboard/new/_components/wizard-intro-step.tsx
@@ -1,10 +1,11 @@
+// Introductory step explaining how the pitch wizard works
 "use client"
 
 import React from "react"
 
 export default function WizardIntroStep() {
   return (
-    <div className="max-w-3xl mx-auto p-8 bg-white rounded-xl shadow-sm">
+    <div className="max-w-full lg:max-w-3xl mx-auto p-4 sm:p-6 lg:p-8 bg-white rounded-xl shadow-sm">
       {/* Main Content */}
       <div className="text-center mb-10">
         <div className="w-20 h-1 bg-blue-500 mx-auto mb-6"></div>

--- a/app/(wizard)/dashboard/new/layout.tsx
+++ b/app/(wizard)/dashboard/new/layout.tsx
@@ -83,16 +83,19 @@ export default function PitchWizardLayout({
        </div>
      </header>
      
-     {/* Main "application card" container */}
-    <div id="main-container" className="flex-1 flex items-center justify-center p-6 md:p-12 w-full">
+    {/* Main "application card" container */}
+    <div
+      id="main-container"
+      className="flex-1 flex items-center justify-center p-4 sm:p-6 lg:p-8 w-full min-h-screen"
+    >
        <div
          id="application-card"
-        className="bg-white rounded-3xl shadow-2xl border border-gray-100 overflow-hidden w-full max-w-4xl mx-auto flex flex-col md:flex-row"
+        className="bg-white rounded-3xl shadow-2xl border border-gray-100 overflow-hidden w-full max-w-7xl mx-auto flex flex-col lg:flex-row h-[90vh] max-h-[900px]"
        >
          {/* Sidebar with vertical progress */}
          <div
            id="sidebar"
-        className="w-full md:w-1/3 flex-shrink-0 mb-6 md:mb-0 md:mr-8 border-b md:border-b-0 md:border-r border-gray-100 bg-white p-8 flex items-center shadow-lg"
+        className="w-full lg:w-64 xl:w-80 flex-shrink-0 border-b lg:border-b-0 lg:border-r border-gray-100 bg-white p-4 sm:p-6 lg:p-8 overflow-y-auto"
          >
            <SectionProgressSidebar 
              current={currentSection}
@@ -102,7 +105,7 @@ export default function PitchWizardLayout({
          </div>
 
          {/* Your wizard content */}
-        <section id="main-content" className="flex-1 p-5 sm:p-8 overflow-y-auto">
+        <section id="main-content" className="flex-1 p-4 sm:p-6 lg:p-8 overflow-y-auto overflow-x-hidden">
            {children}
          </section>
        </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -89,3 +89,13 @@ Global styles for the app.
     @apply bg-background text-foreground;
   }
 }
+
+@media (max-width: 768px) {
+  #sidebar {
+    max-height: 200px;
+  }
+
+  #main-content {
+    min-height: calc(100vh - 300px);
+  }
+}


### PR DESCRIPTION
## Summary
- tune layout for responsive container and sidebar
- polish pitch wizard wrapper and buttons for mobile
- refine intro step styling
- make progress sidebar collapsible on mobile
- add mobile tweaks to global CSS

## Testing
- `npm run lint`
- `npm run type-check`
