### PR TITLE
Redirect to dashboard after Stripe checkout

### DIFF
--- a/app/checkout/success/page.tsx
+++ b/app/checkout/success/page.tsx
@@ -1,7 +1,13 @@
+/*
+Redirect page used by Stripe's success_url. After a customer
+completes payment they land here and are immediately sent to
+the dashboard.
+*/
+
 "use server"
 
 import { redirect } from "next/navigation"
 
 export default async function CheckoutSuccessPage() {
   redirect("/dashboard")
-} 
+}


### PR DESCRIPTION
## Summary
- add a comment clarifying redirect logic on `/checkout/success`

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_683ab469ec408332bc8f3e66aa48dcf5