### PR TITLE
Ensure dashboard shows new credits after purchase

### DIFF
--- a/actions/db/profiles-actions.ts
+++ b/actions/db/profiles-actions.ts
@@ -12,6 +12,7 @@ import {
 } from "@/db/schema/profiles-schema"
 import { ActionState } from "@/types"
 import { eq, sql } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
 
 export async function createProfileAction(
   data: InsertProfile
@@ -139,6 +140,9 @@ export async function addCreditsAction(
     if (!updatedProfile) {
       return { isSuccess: false, message: "Profile not found" }
     }
+
+    // Refresh dashboard cache so the UI shows updated credits immediately
+    revalidatePath("/dashboard")
 
     return {
       isSuccess: true,


### PR DESCRIPTION
## Summary
- refresh the dashboard cache after adding credits to a profile

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_683ab72acfb48332bae0a9da5ab06c3f