### PR TITLE
Fix wizard step persistence

### DIFF
--- a/app/(wizard)/dashboard/new/_components/pitch-wizard/api.ts
+++ b/app/(wizard)/dashboard/new/_components/pitch-wizard/api.ts
@@ -78,6 +78,8 @@ export async function savePitchData(
 
 /**
  * Final pitch generation.
+ *
+ * @param stepToSave - Wizard step to persist when generation begins
  */
 export async function triggerFinalPitch(
   data: PitchWizardFormData,
@@ -87,7 +89,7 @@ export async function triggerFinalPitch(
   toast: ToastFunction,
   setIsPitchLoading: React.Dispatch<React.SetStateAction<boolean>>,
   setFinalPitchError: React.Dispatch<React.SetStateAction<string | null>>,
-  currentStep: number
+  stepToSave: number
 ) {
   try {
     const res = await fetch("/api/pitches/generate", {
@@ -130,7 +132,7 @@ export async function triggerFinalPitch(
       pitchId,
       setPitchId,
       toast,
-      currentStep
+      stepToSave
     )
 
     // poll for final content
@@ -142,7 +144,7 @@ export async function triggerFinalPitch(
       toast,
       setIsPitchLoading,
       setFinalPitchError,
-      currentStep
+      stepToSave
     )
 
     return result.requestId
@@ -170,7 +172,7 @@ export async function pollForPitchContent(
   toast: ToastFunction,
   setIsPitchLoading: React.Dispatch<React.SetStateAction<boolean>>,
   setFinalPitchError: React.Dispatch<React.SetStateAction<string | null>>,
-  currentStep: number = 999 // Use a large number as default to represent the final step
+  stepToSave: number = 999 // Use a large number as default to represent the final step
 ) {
   const pollIntervalMs = 3000
   const maxAttempts = 40
@@ -195,7 +197,7 @@ export async function pollForPitchContent(
           pitchId,
           setPitchId,
           toast,
-          currentStep
+          stepToSave
         )
         return pollJson.pitchContent
       }

--- a/app/(wizard)/dashboard/new/_components/pitch-wizard/index.tsx
+++ b/app/(wizard)/dashboard/new/_components/pitch-wizard/index.tsx
@@ -262,7 +262,9 @@ export default function PitchWizard({ userId, pitchData }: PitchWizardProps) {
                 variant="outline"
                 onClick={handleSaveAndClose}
                 className={`group flex items-center justify-center py-3 font-normal text-gray-600 transition-all duration-200 hover:text-gray-800 ${
-                  currentStep > 1 && currentStep < totalSteps ? "flex-1" : "flex-1"
+                  currentStep > 1 && currentStep < totalSteps
+                    ? "flex-1"
+                    : "flex-1"
                 }`}
               >
                 <Save className="mr-2 size-4 group-hover:scale-110" />

--- a/app/(wizard)/dashboard/new/_components/pitch-wizard/use-wizard.tsx
+++ b/app/(wizard)/dashboard/new/_components/pitch-wizard/use-wizard.tsx
@@ -185,7 +185,7 @@ export function useWizard({ userId, pitchData }: UseWizardOptions) {
           toast,
           setIsPitchLoading,
           setFinalPitchError,
-          currentStep
+          currentStep + 1
         )
       } catch (err) {
         // Error handling is done in the triggerFinalPitch function
@@ -218,7 +218,7 @@ export function useWizard({ userId, pitchData }: UseWizardOptions) {
 
     // Save current step's data
     const formData = methods.getValues()
-    await savePitchData(formData, pitchId, setPitchId, toast, currentStep)
+    await savePitchData(formData, pitchId, setPitchId, toast, currentStep + 1)
 
     // Check if we're moving from last STAR step to review
     const lastStarStep = 4 + starCount * 4


### PR DESCRIPTION
## Summary
- ensure the wizard saves the next step before navigating
- propagate next step information through final pitch generation

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_683d2f2dcdd88332a772ce6227649bb9