### PR TITLE
Add URL-based step routing for pitch wizard

### DIFF
--- a/app/(dashboard)/dashboard/_components/create-pitch-button.tsx
+++ b/app/(dashboard)/dashboard/_components/create-pitch-button.tsx
@@ -30,7 +30,7 @@ export default function CreatePitchButton({ credits }: CreatePitchButtonProps) {
       return
     }
 
-    router.push("/dashboard/new?new=true")
+    router.push("/dashboard/new/1?new=true")
   }
 
   return (

--- a/app/(wizard)/dashboard/new/[pitchId]/[step]/page.tsx
+++ b/app/(wizard)/dashboard/new/[pitchId]/[step]/page.tsx
@@ -1,0 +1,80 @@
+"use server"
+
+import { auth } from "@clerk/nextjs/server"
+import { redirect } from "next/navigation"
+import { getPitchByIdAction } from "@/actions/db/pitches-actions"
+import PitchWizard from "@/app/(wizard)/dashboard/new/_components/pitch-wizard"
+import { Suspense } from "react"
+import { Skeleton } from "@/components/ui/skeleton"
+
+interface PitchWizardStepPageProps {
+  params: Promise<{ pitchId: string; step: string }>
+}
+
+function PitchWizardSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-64" />
+      <Skeleton className="h-64 w-full" />
+      <div className="flex justify-between pt-4">
+        <Skeleton className="h-10 w-20" />
+        <div className="flex space-x-2">
+          <Skeleton className="h-10 w-32" />
+          <Skeleton className="h-10 w-20" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+async function PitchWizardFetcher({
+  pitchId,
+  stepNum,
+  userId
+}: {
+  pitchId: string
+  stepNum: number
+  userId: string
+}) {
+  const pitchResult = await getPitchByIdAction(pitchId, userId)
+
+  if (!pitchResult.isSuccess || !pitchResult.data) {
+    redirect("/dashboard")
+  }
+
+  return (
+    <PitchWizard
+      userId={userId}
+      pitchData={pitchResult.data}
+      initialStep={stepNum}
+    />
+  )
+}
+
+export default async function PitchWizardStepPage({
+  params
+}: PitchWizardStepPageProps) {
+  const { pitchId, step } = await params
+  const stepNum = parseInt(step, 10)
+
+  if (!Number.isFinite(stepNum) || stepNum < 1 || stepNum > 100) {
+    redirect(`/dashboard/new/${pitchId}/1`)
+  }
+
+  const { userId } = await auth()
+  if (!userId) {
+    redirect("/login")
+  }
+
+  return (
+    <div className="container mx-auto max-w-5xl px-4 py-6 sm:px-6">
+      <Suspense fallback={<PitchWizardSkeleton />}>
+        <PitchWizardFetcher
+          pitchId={pitchId}
+          stepNum={stepNum}
+          userId={userId}
+        />
+      </Suspense>
+    </div>
+  )
+}

--- a/app/(wizard)/dashboard/new/[pitchId]/page.tsx
+++ b/app/(wizard)/dashboard/new/[pitchId]/page.tsx
@@ -24,44 +24,6 @@
 import { auth } from "@clerk/nextjs/server"
 import { redirect } from "next/navigation"
 import { getPitchByIdAction } from "@/actions/db/pitches-actions"
-import PitchWizard from "@/app/(wizard)/dashboard/new/_components/pitch-wizard"
-import { Suspense } from "react"
-import { Skeleton } from "@/components/ui/skeleton"
-
-function PitchWizardSkeleton() {
-  return (
-    <div className="space-y-6">
-      <Skeleton className="h-8 w-64" />
-      <Skeleton className="h-64 w-full" />
-      <div className="flex justify-between pt-4">
-        <Skeleton className="h-10 w-20" />
-        <div className="flex space-x-2">
-          <Skeleton className="h-10 w-32" />
-          <Skeleton className="h-10 w-20" />
-        </div>
-      </div>
-    </div>
-  )
-}
-
-async function PitchWizardFetcher({ pitchId }: { pitchId: string }) {
-  const { userId } = await auth()
-
-  if (!userId) {
-    redirect("/login")
-  }
-
-  // Fetch the pitch by ID
-  const pitchResult = await getPitchByIdAction(pitchId, userId)
-
-  // If the pitch is not found or doesn't belong to the user, redirect to dashboard
-  if (!pitchResult.isSuccess) {
-    redirect("/dashboard")
-  }
-
-  // Pass the pitch data to the PitchWizard component
-  return <PitchWizard userId={userId} pitchData={pitchResult.data} />
-}
 
 export default async function ResumePitchPage({
   params
@@ -70,11 +32,16 @@ export default async function ResumePitchPage({
 }) {
   const { pitchId } = await params
 
-  return (
-    <div className="container mx-auto max-w-5xl px-4 py-6 sm:px-6">
-      <Suspense fallback={<PitchWizardSkeleton />}>
-        <PitchWizardFetcher pitchId={pitchId} />
-      </Suspense>
-    </div>
-  )
+  const { userId } = await auth()
+  if (!userId) {
+    redirect("/login")
+  }
+
+  const result = await getPitchByIdAction(pitchId, userId)
+  if (!result.isSuccess || !result.data) {
+    redirect("/dashboard")
+  }
+
+  const step = result.data.currentStep || 1
+  redirect(`/dashboard/new/${pitchId}/${step}`)
 }

--- a/app/(wizard)/dashboard/new/[step]/page.tsx
+++ b/app/(wizard)/dashboard/new/[step]/page.tsx
@@ -1,0 +1,33 @@
+"use server"
+
+import { auth } from "@clerk/nextjs/server"
+import { redirect } from "next/navigation"
+import PitchWizard from "@/app/(wizard)/dashboard/new/_components/pitch-wizard"
+import CheckStoredPitch from "@/app/(wizard)/dashboard/new/_components/check-stored-pitch"
+
+interface NewPitchStepPageProps {
+  params: Promise<{ step: string }>
+}
+
+export default async function NewPitchStepPage({
+  params
+}: NewPitchStepPageProps) {
+  const { step } = await params
+  const stepNum = parseInt(step, 10)
+
+  if (!Number.isFinite(stepNum) || stepNum < 1 || stepNum > 100) {
+    redirect("/dashboard/new/1")
+  }
+
+  const { userId } = await auth()
+  if (!userId) {
+    redirect("/login")
+  }
+
+  return (
+    <div className="size-full">
+      <CheckStoredPitch />
+      <PitchWizard userId={userId} initialStep={stepNum} />
+    </div>
+  )
+}

--- a/app/(wizard)/dashboard/new/_components/pitch-wizard/index.tsx
+++ b/app/(wizard)/dashboard/new/_components/pitch-wizard/index.tsx
@@ -26,9 +26,14 @@ import { useWizard } from "./use-wizard"
 interface PitchWizardProps {
   userId: string
   pitchData?: SelectPitch
+  initialStep?: number
 }
 
-export default function PitchWizard({ userId, pitchData }: PitchWizardProps) {
+export default function PitchWizard({
+  userId,
+  pitchData,
+  initialStep
+}: PitchWizardProps) {
   const {
     methods,
     currentStep,
@@ -49,7 +54,7 @@ export default function PitchWizard({ userId, pitchData }: PitchWizardProps) {
     handleSaveAndClose,
     handleSubmitFinal,
     handlePitchLoaded
-  } = useWizard({ userId, pitchData })
+  } = useWizard({ userId, pitchData, initialStep })
 
   // Render the appropriate step component based on current step
   function renderStep() {

--- a/app/(wizard)/dashboard/new/_components/pitch-wizard/use-wizard.tsx
+++ b/app/(wizard)/dashboard/new/_components/pitch-wizard/use-wizard.tsx
@@ -18,14 +18,24 @@ import { validateStep } from "./validation"
 interface UseWizardOptions {
   userId: string
   pitchData?: SelectPitch
+  initialStep?: number
 }
 
-export function useWizard({ userId, pitchData }: UseWizardOptions) {
+export function useWizard({
+  userId,
+  pitchData,
+  initialStep
+}: UseWizardOptions) {
   const router = useRouter()
   const { toast } = useToast()
 
   // Local wizard state
-  const [currentStep, setCurrentStep] = useState(pitchData?.currentStep || 1)
+  const [currentStep, setCurrentStep] = useState(() => {
+    if (initialStep && Number.isInteger(initialStep) && initialStep > 0) {
+      return initialStep
+    }
+    return pitchData?.currentStep || 1
+  })
   const [pitchId, setPitchId] = useState<string | undefined>(pitchData?.id)
   const [isPitchLoading, setIsPitchLoading] = useState(false)
   const [finalPitchError, setFinalPitchError] = useState<string | null>(null)
@@ -167,6 +177,16 @@ export function useWizard({ userId, pitchData }: UseWizardOptions) {
 
     return () => clearTimeout(timeout)
   }, [currentStep, pitchId, methods, setPitchId, toast])
+
+  // Sync URL with current step
+  useEffect(() => {
+    const step = currentStep
+    if (pitchId) {
+      router.replace(`/dashboard/new/${pitchId}/${step}`)
+    } else {
+      router.replace(`/dashboard/new/${step}`)
+    }
+  }, [currentStep, pitchId, router])
 
   // Handler for navigating to a specific section
   const handleSectionNavigate = useCallback(

--- a/app/(wizard)/dashboard/new/page.tsx
+++ b/app/(wizard)/dashboard/new/page.tsx
@@ -21,25 +21,8 @@
 
 "use server"
 
-import { auth } from "@clerk/nextjs/server"
 import { redirect } from "next/navigation"
-import PitchWizard from "@/app/(wizard)/dashboard/new/_components/pitch-wizard"
-import CheckStoredPitch from "@/app/(wizard)/dashboard/new/_components/check-stored-pitch"
 
 export default async function CreateNewPitchPage() {
-  // Check if the user is authenticated
-  const { userId } = await auth()
-
-  if (!userId) {
-    // If not authenticated, redirect to login
-    redirect("/login")
-  }
-
-  // Render the client-side wizard, passing the userId
-  return (
-    <div className="size-full">
-      <CheckStoredPitch />
-      <PitchWizard userId={userId} />
-    </div>
-  )
+  redirect("/dashboard/new/1")
 }


### PR DESCRIPTION
## Summary
- create routes for `/dashboard/new/[step]` and `/dashboard/new/[pitchId]/[step]`
- redirect old wizard entry points to the new step routes
- add optional `initialStep` prop and sync URL in wizard
- update wizard hook to prioritise URL step and update address bar
- adjust create pitch button for new route scheme

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_683d433645d483328926d11c33fcea27