### PR TITLE
Fix profile caching via server actions

### DIFF
--- a/actions/db/profiles-actions.ts
+++ b/actions/db/profiles-actions.ts
@@ -13,12 +13,14 @@ import {
 import { ActionState } from "@/types"
 import { eq, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
+import { setCachedProfile } from "@/lib/profile-cache"
 
 export async function createProfileAction(
   data: InsertProfile
 ): Promise<ActionState<SelectProfile>> {
   try {
     const [newProfile] = await db.insert(profilesTable).values(data).returning()
+    await setCachedProfile(newProfile)
     return {
       isSuccess: true,
       message: "Profile created successfully",
@@ -67,6 +69,7 @@ export async function updateProfileAction(
       return { isSuccess: false, message: "Profile not found to update" }
     }
 
+    await setCachedProfile(updatedProfile)
     return {
       isSuccess: true,
       message: "Profile updated successfully",
@@ -96,6 +99,7 @@ export async function updateProfileByStripeCustomerIdAction(
       }
     }
 
+    await setCachedProfile(updatedProfile)
     return {
       isSuccess: true,
       message: "Profile updated by Stripe customer ID successfully",
@@ -144,6 +148,7 @@ export async function addCreditsAction(
     // Refresh dashboard cache so the UI shows updated credits immediately
     revalidatePath("/dashboard")
 
+    await setCachedProfile(updatedProfile)
     return {
       isSuccess: true,
       message: "Credits added successfully",
@@ -179,6 +184,7 @@ export async function spendCreditsAction(
       .where(eq(profilesTable.userId, userId))
       .returning()
 
+    await setCachedProfile(updatedProfile)
     return {
       isSuccess: true,
       message: "Credits used successfully",

--- a/actions/index.ts
+++ b/actions/index.ts
@@ -6,4 +6,5 @@
 export * from "./db/pitches-actions"
 export * from "./db/profiles-actions"
 export * from "./agent-actions"
-export * from "./storage/resume-storage-actions" 
+export * from "./storage/resume-storage-actions"
+export * from "./profile-cache-actions"

--- a/actions/profile-cache-actions.ts
+++ b/actions/profile-cache-actions.ts
@@ -1,0 +1,33 @@
+"use server"
+
+/*
+Server actions for manipulating profile cache cookies.
+*/
+
+import type { SelectProfile } from "@/db/schema/profiles-schema"
+import { setCachedProfile, clearCachedProfile } from "@/lib/profile-cache"
+import type { ActionState } from "@/types"
+
+export async function cacheProfileAction(
+  profile: SelectProfile
+): Promise<ActionState<void>> {
+  try {
+    await setCachedProfile(profile)
+    return { isSuccess: true, message: "Profile cached", data: undefined }
+  } catch (error) {
+    console.error("Error caching profile:", error)
+    return { isSuccess: false, message: "Failed to cache profile" }
+  }
+}
+
+export async function clearProfileCacheAction(
+  userId: string
+): Promise<ActionState<void>> {
+  try {
+    await clearCachedProfile(userId)
+    return { isSuccess: true, message: "Profile cache cleared", data: undefined }
+  } catch (error) {
+    console.error("Error clearing profile cache:", error)
+    return { isSuccess: false, message: "Failed to clear profile cache" }
+  }
+}

--- a/app/(dashboard)/dashboard/_components/dashboard-sidebar.tsx
+++ b/app/(dashboard)/dashboard/_components/dashboard-sidebar.tsx
@@ -25,6 +25,8 @@
 import Link from "next/link"
 import { Settings, CreditCard } from "lucide-react"
 import { getProfileByUserIdAction } from "@/actions/db/profiles-actions"
+import { getCachedProfile } from "@/lib/profile-cache"
+import { cacheProfileAction } from "@/actions/profile-cache-actions"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
@@ -57,11 +59,15 @@ interface DashboardSidebarProps {
 export default async function DashboardSidebar({
   userId
 }: DashboardSidebarProps) {
-  // Retrieve user profile for credits display
-  const profileResult = await getProfileByUserIdAction(userId)
-  const credits = profileResult.isSuccess
-    ? (profileResult.data?.credits ?? 0)
-    : 0
+  let profile = await getCachedProfile(userId)
+  if (!profile) {
+    const profileResult = await getProfileByUserIdAction(userId)
+    if (profileResult.isSuccess && profileResult.data) {
+      profile = profileResult.data
+      await cacheProfileAction(profile)
+    }
+  }
+  const credits = profile?.credits ?? 0
 
   return (
     <Sidebar variant="inset">

--- a/app/(wizard)/dashboard/new/[pitchId]/step/[step]/page.tsx
+++ b/app/(wizard)/dashboard/new/[pitchId]/step/[step]/page.tsx
@@ -23,12 +23,12 @@ function PitchWizardSkeleton() {
   )
 }
 
-async function PitchWizardFetcher({ 
-  pitchId, 
-  stepNumber 
-}: { 
+async function PitchWizardFetcher({
+  pitchId,
+  stepNumber
+}: {
   pitchId: string
-  stepNumber: number 
+  stepNumber: number
 }) {
   const { userId } = await auth()
 
@@ -46,8 +46,8 @@ async function PitchWizardFetcher({
 
   // Pass the pitch data to the PitchWizard component
   return (
-    <PitchWizard 
-      userId={userId} 
+    <PitchWizard
+      userId={userId}
       pitchData={pitchResult.data}
       initialStep={stepNumber}
     />
@@ -61,7 +61,7 @@ export default async function ResumePitchWithStepPage({
 }) {
   const { pitchId, step } = await params
   const stepNumber = parseInt(step, 10)
-  
+
   // Validate step number
   if (isNaN(stepNumber) || stepNumber < 1 || stepNumber > 50) {
     redirect(`/dashboard/new/${pitchId}/step/1`)
@@ -74,4 +74,4 @@ export default async function ResumePitchWithStepPage({
       </Suspense>
     </div>
   )
-} 
+}

--- a/app/(wizard)/dashboard/new/step/[step]/page.tsx
+++ b/app/(wizard)/dashboard/new/step/[step]/page.tsx
@@ -14,10 +14,10 @@ export default async function CreateNewPitchWithStepPage({
   if (!userId) {
     redirect("/login")
   }
-  
+
   const { step } = await params
   const stepNumber = parseInt(step, 10)
-  
+
   // Validate step number (1-based, reasonable range)
   if (isNaN(stepNumber) || stepNumber < 1 || stepNumber > 50) {
     redirect("/dashboard/new/step/1")
@@ -29,4 +29,4 @@ export default async function CreateNewPitchWithStepPage({
       <PitchWizard userId={userId} initialStep={stepNumber} />
     </div>
   )
-} 
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,9 @@ import { Toaster } from "@/components/ui/toaster"
 import { Providers } from "@/components/utilities/providers"
 import { TailwindIndicator } from "@/components/utilities/tailwind-indicator"
 import { cn } from "@/lib/utils"
+import { getCachedProfile } from "@/lib/profile-cache"
+import { cacheProfileAction } from "@/actions/profile-cache-actions"
+import type { SelectProfile } from "@/db/schema"
 import { ClerkProvider } from "@clerk/nextjs"
 import { auth } from "@clerk/nextjs/server"
 import type { Metadata } from "next"
@@ -26,11 +29,23 @@ export default async function RootLayout({
   children: React.ReactNode
 }) {
   const { userId } = await auth()
+  let initialProfile: SelectProfile | null = null
 
   if (userId) {
-    const profileRes = await getProfileByUserIdAction(userId)
-    if (!profileRes.isSuccess) {
-      await createProfileAction({ userId })
+    initialProfile = await getCachedProfile(userId)
+    if (!initialProfile) {
+      const profileRes = await getProfileByUserIdAction(userId)
+      if (profileRes.isSuccess && profileRes.data) {
+        initialProfile = profileRes.data
+      } else {
+        const created = await createProfileAction({ userId })
+        if (created.isSuccess) {
+          initialProfile = created.data
+        }
+      }
+      if (initialProfile) {
+        await cacheProfileAction(initialProfile)
+      }
     }
   }
 
@@ -51,6 +66,7 @@ export default async function RootLayout({
             defaultTheme="light"
             enableSystem={false}
             disableTransitionOnChange
+            initialProfile={initialProfile}
           >
             {children}
 

--- a/components/utilities/profile-provider.tsx
+++ b/components/utilities/profile-provider.tsx
@@ -1,0 +1,35 @@
+// Provides profile context to client components.
+"use client"
+
+import { createContext, useContext, useState, ReactNode } from "react"
+import { SelectProfile } from "@/db/schema"
+
+interface ProfileContextValue {
+  profile: SelectProfile | null
+  setProfile: (profile: SelectProfile | null) => void
+}
+
+const ProfileContext = createContext<ProfileContextValue | undefined>(undefined)
+
+export function ProfileProvider({
+  initialProfile,
+  children
+}: {
+  initialProfile: SelectProfile | null
+  children: ReactNode
+}) {
+  const [profile, setProfile] = useState<SelectProfile | null>(initialProfile)
+  return (
+    <ProfileContext.Provider value={{ profile, setProfile }}>
+      {children}
+    </ProfileContext.Provider>
+  )
+}
+
+export function useProfile() {
+  const ctx = useContext(ProfileContext)
+  if (!ctx) {
+    throw new Error("useProfile must be used within a ProfileProvider")
+  }
+  return ctx
+}

--- a/components/utilities/providers.tsx
+++ b/components/utilities/providers.tsx
@@ -9,11 +9,24 @@ import {
   ThemeProvider as NextThemesProvider,
   ThemeProviderProps
 } from "next-themes"
+import { ProfileProvider } from "@/components/utilities/profile-provider"
+import type { SelectProfile } from "@/db/schema"
 
-export const Providers = ({ children, ...props }: ThemeProviderProps) => {
+interface ProvidersProps extends ThemeProviderProps {
+  initialProfile?: SelectProfile | null
+}
+export const Providers = ({
+  children,
+  initialProfile,
+  ...props
+}: ProvidersProps) => {
   return (
     <NextThemesProvider {...props}>
-      <TooltipProvider>{children}</TooltipProvider>
+      <TooltipProvider>
+        <ProfileProvider initialProfile={initialProfile || null}>
+          {children}
+        </ProfileProvider>
+      </TooltipProvider>
     </NextThemesProvider>
   )
 }

--- a/lib/profile-cache.ts
+++ b/lib/profile-cache.ts
@@ -1,0 +1,35 @@
+//
+// Utility functions for caching user profiles in cookies.
+//
+
+import { cookies } from "next/headers"
+import { SelectProfile } from "@/db/schema/profiles-schema"
+
+const COOKIE_PREFIX = "profile_"
+const MAX_AGE = 60 * 60 * 24 // 1 day
+
+export async function getCachedProfile(
+  userId: string
+): Promise<SelectProfile | null> {
+  const store = await cookies()
+  const cookie = store.get(`${COOKIE_PREFIX}${userId}`)
+  if (!cookie) return null
+  try {
+    return JSON.parse(cookie.value) as SelectProfile
+  } catch {
+    return null
+  }
+}
+
+export async function setCachedProfile(profile: SelectProfile) {
+  const store = await cookies()
+  store.set(`${COOKIE_PREFIX}${profile.userId}`, JSON.stringify(profile), {
+    path: "/",
+    maxAge: MAX_AGE
+  })
+}
+
+export async function clearCachedProfile(userId: string) {
+  const store = await cookies()
+  store.delete(`${COOKIE_PREFIX}${userId}`)
+}


### PR DESCRIPTION
## Summary
- add `profile-cache-actions.ts` server actions
- export cache actions from `actions/index.ts`
- update root layout and dashboard sidebar to use `cacheProfileAction`
- document `ProfileProvider` with a header comment

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_683d925b84208332a8672f960ab8709c