### PR TITLE
Update pitch wizard limits and recommendations

### DIFF
--- a/app/(wizard)/dashboard/new/[pitchId]/step/[step]/page.tsx
+++ b/app/(wizard)/dashboard/new/[pitchId]/step/[step]/page.tsx
@@ -23,12 +23,12 @@ function PitchWizardSkeleton() {
   )
 }
 
-async function PitchWizardFetcher({ 
-  pitchId, 
-  stepNumber 
-}: { 
+async function PitchWizardFetcher({
+  pitchId,
+  stepNumber
+}: {
   pitchId: string
-  stepNumber: number 
+  stepNumber: number
 }) {
   const { userId } = await auth()
 
@@ -46,8 +46,8 @@ async function PitchWizardFetcher({
 
   // Pass the pitch data to the PitchWizard component
   return (
-    <PitchWizard 
-      userId={userId} 
+    <PitchWizard
+      userId={userId}
       pitchData={pitchResult.data}
       initialStep={stepNumber}
     />
@@ -61,7 +61,7 @@ export default async function ResumePitchWithStepPage({
 }) {
   const { pitchId, step } = await params
   const stepNumber = parseInt(step, 10)
-  
+
   // Validate step number
   if (isNaN(stepNumber) || stepNumber < 1 || stepNumber > 50) {
     redirect(`/dashboard/new/${pitchId}/step/1`)
@@ -74,4 +74,4 @@ export default async function ResumePitchWithStepPage({
       </Suspense>
     </div>
   )
-} 
+}

--- a/app/(wizard)/dashboard/new/_components/guidance-step.tsx
+++ b/app/(wizard)/dashboard/new/_components/guidance-step.tsx
@@ -40,6 +40,7 @@ export default function GuidanceStep({
   const albertGuidance = watch("albertGuidance") // existing guidance
   const starExamplesCount = watch("starExamplesCount")
   const starExampleDescriptions = watch("starExampleDescriptions") || []
+  const pitchWordLimit = watch("pitchWordLimit")
 
   // Determine the definitive pitch ID to use
   // Prioritize the ID from props (coming from useWizard state)
@@ -171,8 +172,10 @@ export default function GuidanceStep({
     }
   }
 
-  const possibleStarCounts = ["1", "2", "3", "4"]
+  const possibleStarCounts = ["2", "3", "4"]
   const starCount = starExamplesCount || "2"
+  const recommendedCount =
+    pitchWordLimit < 550 ? "2" : pitchWordLimit <= 700 ? "3" : "4"
   const [tipsOpen, setTipsOpen] = useState<string | undefined>(undefined)
 
   // Log form state of albertGuidance before rendering
@@ -262,27 +265,33 @@ export default function GuidanceStep({
           <p className="font-medium text-gray-700">
             How many STAR examples do you want to include?
           </p>
-          <div className="grid grid-cols-4 gap-4">
+          <div className="grid grid-cols-3 gap-4">
             {possibleStarCounts.map(val => (
-              <button
-                key={val}
-                onClick={() => handleStarExamplesCountChange(val)}
-                className={`flex h-12 items-center justify-center rounded-xl transition-all duration-200 ${
-                  starCount === val
-                    ? "font-medium"
-                    : "bg-gray-50 text-gray-700 hover:bg-gray-100"
-                }`}
-                style={
-                  starCount === val
-                    ? {
-                        backgroundColor: "#eef2ff",
-                        color: "#444ec1"
-                      }
-                    : {}
-                }
-              >
-                {val}
-              </button>
+              <div key={val} className="flex flex-col items-center gap-1">
+                <button
+                  onClick={() => handleStarExamplesCountChange(val)}
+                  className={`flex h-12 w-full items-center justify-center rounded-xl transition-all duration-200 ${
+                    starCount === val
+                      ? "font-medium"
+                      : "bg-gray-50 text-gray-700 hover:bg-gray-100"
+                  }`}
+                  style={
+                    starCount === val
+                      ? {
+                          backgroundColor: "#eef2ff",
+                          color: "#444ec1"
+                        }
+                      : {}
+                  }
+                >
+                  {val}
+                </button>
+                {recommendedCount === val && (
+                  <span className="text-xs text-gray-500">
+                    Recommended by Recruiters
+                  </span>
+                )}
+              </div>
             ))}
           </div>
           {errors.starExamplesCount && (

--- a/app/(wizard)/dashboard/new/_components/pitch-wizard/helpers.tsx
+++ b/app/(wizard)/dashboard/new/_components/pitch-wizard/helpers.tsx
@@ -73,7 +73,7 @@ export function mapExistingDataToDefaults(
       relevantExperience: "",
       albertGuidance: "",
       starExamples: [createEmptyStarExample()],
-      starExamplesCount: "1",
+      starExamplesCount: "2",
       starExampleDescriptions: [],
       pitchContent: "",
       agentExecutionId: ""
@@ -97,13 +97,13 @@ export function mapExistingDataToDefaults(
 
   const sc = pitchData.starExamplesCount
     ? String(pitchData.starExamplesCount)
-    : "1"
+    : "2"
 
   // Define valid star counts and derive the enum type
-  const validStarCounts = ["1", "2", "3", "4"] as const
+  const validStarCounts = ["2", "3", "4"] as const
   type StarCountEnum = (typeof validStarCounts)[number]
 
-  const safeStarCount = validStarCounts.includes(sc as any) ? sc : "1"
+  const safeStarCount = validStarCounts.includes(sc as any) ? sc : "2"
 
   return {
     userId: pitchData.userId,

--- a/app/(wizard)/dashboard/new/_components/pitch-wizard/schema.ts
+++ b/app/(wizard)/dashboard/new/_components/pitch-wizard/schema.ts
@@ -61,7 +61,7 @@ export const pitchWizardSchema = z.object({
   roleName: z.string().min(10).max(150),
   organisationName: z.string().min(10).max(150),
   roleLevel: z.enum(["APS1", "APS2", "APS3", "APS4", "APS5", "APS6", "EL1"]),
-  pitchWordLimit: z.number().min(400).max(1250),
+  pitchWordLimit: z.number().min(400).max(1000),
   roleDescription: z
     .string()
     .min(1000, "Role description must be at least 1,000 characters")
@@ -69,7 +69,7 @@ export const pitchWizardSchema = z.object({
   relevantExperience: z.string().min(1000).max(10000),
   albertGuidance: z.string().min(1),
 
-  starExamplesCount: z.enum(["1", "2", "3", "4"]).default("1"),
+  starExamplesCount: z.enum(["2", "3", "4"]).default("2"),
   starExampleDescriptions: z.array(z.string().min(10).max(100)).optional(),
   starExamples: z.array(starExampleSchema).min(1, "At least one STAR example"),
 

--- a/app/(wizard)/dashboard/new/_components/pitch-wizard/use-wizard.tsx
+++ b/app/(wizard)/dashboard/new/_components/pitch-wizard/use-wizard.tsx
@@ -57,7 +57,7 @@ export function useWizard({
   })
 
   // Watch for starExamplesCount
-  const starCount = parseInt(methods.watch("starExamplesCount") || "1", 10)
+  const starCount = parseInt(methods.watch("starExamplesCount") || "2", 10)
   const totalSteps = 4 + starCount * 4 + 1
 
   // Get current section and header

--- a/app/(wizard)/dashboard/new/_components/role-step.tsx
+++ b/app/(wizard)/dashboard/new/_components/role-step.tsx
@@ -239,7 +239,8 @@ export default function RoleStep() {
                       {...field}
                       type="number"
                       min={400}
-                      placeholder="Minimum 400 words"
+                      max={1000}
+                      placeholder="Enter between 400 and 1000 words"
                       className="h-12 w-full rounded-lg border border-gray-200 bg-white px-4 text-base transition-all duration-200 lg:h-12 lg:text-sm"
                       style={
                         {

--- a/app/(wizard)/dashboard/new/step/[step]/page.tsx
+++ b/app/(wizard)/dashboard/new/step/[step]/page.tsx
@@ -14,10 +14,10 @@ export default async function CreateNewPitchWithStepPage({
   if (!userId) {
     redirect("/login")
   }
-  
+
   const { step } = await params
   const stepNumber = parseInt(step, 10)
-  
+
   // Validate step number (1-based, reasonable range)
   if (isNaN(stepNumber) || stepNumber < 1 || stepNumber > 50) {
     redirect("/dashboard/new/step/1")
@@ -29,4 +29,4 @@ export default async function CreateNewPitchWithStepPage({
       <PitchWizard userId={userId} initialStep={stepNumber} />
     </div>
   )
-} 
+}

--- a/app/api/pitches/route.ts
+++ b/app/api/pitches/route.ts
@@ -53,7 +53,7 @@ export async function POST(request: Request) {
       starExamples: body.starExamples || [],
       starExamplesCount: body.starExamplesCount
         ? parseInt(body.starExamplesCount, 10)
-        : 1,
+        : 2,
       starExampleDescriptions: body.starExampleDescriptions || [],
 
       // generated content

--- a/db/schema/pitches-schema.ts
+++ b/db/schema/pitches-schema.ts
@@ -84,7 +84,7 @@ export const pitchesTable = pgTable("pitches", {
 
   /* bookkeeping */
   status: pitchStatusEnum("status").default("draft").notNull(),
-  starExamplesCount: integer("star_examples_count").default(1).notNull(),
+  starExamplesCount: integer("star_examples_count").default(2).notNull(),
   currentStep: integer("current_step").default(1).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")

--- a/lib/schemas/pitchSchemas.ts
+++ b/lib/schemas/pitchSchemas.ts
@@ -59,7 +59,7 @@ export const updatePitchSchema = z
     userId: z.string().optional(),
     roleName: z.string().min(10).max(150).optional(),
     roleLevel: z.string().nonempty().optional(),
-    pitchWordLimit: z.number().min(400).max(1250).optional(),
+    pitchWordLimit: z.number().min(400).max(1000).optional(),
     roleDescription: z.string().optional().nullable(),
     relevantExperience: z.string().min(1000).max(10000).optional(),
 
@@ -72,8 +72,8 @@ export const updatePitchSchema = z
     // Add agentExecutionId for PromptLayer integration
     agentExecutionId: z.string().optional().nullable(),
 
-    // starExamplesCount can be 1..10
-    starExamplesCount: z.number().min(1).max(4).optional(),
+    // starExamplesCount can be 2..4
+    starExamplesCount: z.number().min(2).max(4).optional(),
 
     // starExampleDescriptions for short descriptions of each STAR example
     starExampleDescriptions: z.array(z.string().min(10).max(100)).optional(),


### PR DESCRIPTION
## Summary
- enforce 1000 word cap and STAR example limits
- note recruiter recommendations for STAR example counts
- store new defaults in DB schema and APIs

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68428ab2ee708332ae53939d242f3fe4