### PR TITLE
Implement prefetch for wizard steps

### DIFF
--- a/app/(wizard)/dashboard/new/_components/pitch-wizard/use-wizard.tsx
+++ b/app/(wizard)/dashboard/new/_components/pitch-wizard/use-wizard.tsx
@@ -179,6 +179,16 @@ export function useWizard({
     return () => clearTimeout(timeout)
   }, [currentStep, pitchId, methods, setPitchId, toast])
 
+  // Prefetch the next step to avoid loading flashes
+  useEffect(() => {
+    const next = Math.min(currentStep + 1, totalSteps)
+    const url = pitchId
+      ? `/dashboard/new/${pitchId}/step/${next}`
+      : `/dashboard/new/step/${next}`
+
+    router.prefetch(url)
+  }, [currentStep, pitchId, totalSteps, router])
+
   // Sync URL with current step
   useEffect(() => {
     const step = currentStep


### PR DESCRIPTION
## Summary
- prefetch next wizard step to eliminate skeleton flashes

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6842d544dacc83328f13b87f769bd3bd