### PR TITLE
Add adaptive word count indicator

### DIFF
--- a/app/(dashboard)/dashboard/_components/desktop-header.tsx
+++ b/app/(dashboard)/dashboard/_components/desktop-header.tsx
@@ -16,4 +16,4 @@ export default function DesktopHeader() {
       </div>
     </header>
   )
-} 
+}

--- a/app/(dashboard)/dashboard/_components/mobile-header.tsx
+++ b/app/(dashboard)/dashboard/_components/mobile-header.tsx
@@ -22,7 +22,7 @@ export default function MobileHeader() {
         </Button>
         <h1 className="text-lg font-semibold text-gray-800">Pitch Manager</h1>
       </div>
-      
+
       <div className="flex items-center">
         <UserButton
           appearance={{

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -82,7 +82,7 @@ export default async function DashboardLayout({
         <div className="flex flex-1 flex-col overflow-hidden">
           {/* Mobile Header - Only visible on mobile */}
           <MobileHeader />
-          
+
           {/* Desktop Header - Only visible on desktop */}
           <DesktopHeader />
 

--- a/app/(wizard)/dashboard/new/[pitchId]/page.tsx
+++ b/app/(wizard)/dashboard/new/[pitchId]/page.tsx
@@ -42,7 +42,7 @@ export default async function ResumePitchPage({
 
   const { pitchId } = await params
   const { step } = await searchParams
-  
+
   // Fetch the pitch by ID
   const pitchResult = await getPitchByIdAction(pitchId, userId)
 
@@ -51,10 +51,15 @@ export default async function ResumePitchPage({
     redirect("/dashboard")
   }
 
-  const initialStep = step ? parseInt(step, 10) : pitchResult.data.currentStep || 1
+  const initialStep = step
+    ? parseInt(step, 10)
+    : pitchResult.data.currentStep || 1
 
   // Validate step number
-  const validStep = !isNaN(initialStep) && initialStep > 0 && initialStep <= 50 ? initialStep : 1
+  const validStep =
+    !isNaN(initialStep) && initialStep > 0 && initialStep <= 50
+      ? initialStep
+      : 1
 
   return (
     <div className="size-full">

--- a/app/(wizard)/dashboard/new/_components/action-step.tsx
+++ b/app/(wizard)/dashboard/new/_components/action-step.tsx
@@ -2,7 +2,12 @@
 
 // Handles the Action step where users list what they did in each STAR example
 import { useFormContext } from "react-hook-form"
-import { PitchWizardFormData } from "./pitch-wizard/schema"
+import {
+  PitchWizardFormData,
+  starExampleSchema,
+  actionStepSchema
+} from "./pitch-wizard/schema"
+import WordCountIndicator from "./word-count-indicator"
 import { useState, useEffect } from "react"
 import { v4 as uuidv4 } from "uuid"
 import {
@@ -30,11 +35,6 @@ import {
 } from "@/components/ui/accordion"
 import { cn } from "@/lib/utils"
 import type { ActionStep as ActionStepType } from "@/types/action-steps-types"
-
-// Add word count helper
-function countWords(text: string) {
-  return text.trim().split(/\s+/).filter(Boolean).length
-}
 
 interface ActionStepProps {
   /**
@@ -356,20 +356,16 @@ function StepItem({ step, onSave, exampleIndex }: StepItemProps) {
   const outcomeError = (
     errors.starExamples?.[exampleIndex]?.action?.steps as any
   )?.[stepIndex]?.["what-was-the-outcome-of-this-step-optional"]
-  const [what, setWhat] = useState(
-    step["what-did-you-specifically-do-in-this-step"]
+  const [what, setWhat] = useState<string>(
+    step["what-did-you-specifically-do-in-this-step"] || ""
   )
-  const [outcome, setOutcome] = useState(
-    step["what-was-the-outcome-of-this-step-optional"]
+  const [outcome, setOutcome] = useState<string>(
+    step["what-was-the-outcome-of-this-step-optional"] || ""
   )
-
-  // Word counts
-  const whatWords = countWords(what || "")
-  const outcomeWords = countWords(outcome || "")
 
   useEffect(() => {
-    setWhat(step["what-did-you-specifically-do-in-this-step"])
-    setOutcome(step["what-was-the-outcome-of-this-step-optional"])
+    setWhat(step["what-did-you-specifically-do-in-this-step"] || "")
+    setOutcome(step["what-was-the-outcome-of-this-step-optional"] || "")
   }, [step])
 
   const handleSave = () => {
@@ -452,9 +448,14 @@ function StepItem({ step, onSave, exampleIndex }: StepItemProps) {
                   e.target.style.boxShadow = "none"
                 }}
               />
-              <div className="absolute bottom-2 right-3 text-xs text-gray-400">
-                {whatWords}
-              </div>
+              <WordCountIndicator
+                schema={
+                  actionStepSchema.shape[
+                    "what-did-you-specifically-do-in-this-step"
+                  ]
+                }
+                text={what}
+              />
               {whatError && (
                 <p className="mt-1 text-sm text-red-500">
                   {whatError.message as string}
@@ -493,9 +494,14 @@ function StepItem({ step, onSave, exampleIndex }: StepItemProps) {
                   e.target.style.boxShadow = "none"
                 }}
               />
-              <div className="absolute bottom-2 right-3 text-xs text-gray-400">
-                {outcomeWords}
-              </div>
+              <WordCountIndicator
+                schema={
+                  actionStepSchema.shape[
+                    "what-was-the-outcome-of-this-step-optional"
+                  ]
+                }
+                text={outcome}
+              />
               {outcomeError && (
                 <p className="mt-1 text-sm text-red-500">
                   {outcomeError.message as string}

--- a/app/(wizard)/dashboard/new/_components/pitch-wizard/schema.ts
+++ b/app/(wizard)/dashboard/new/_components/pitch-wizard/schema.ts
@@ -17,25 +17,28 @@ function countWords(text: string) {
  * Validate that a string has a word count within a specified range.
  */
 function wordRange(min: number, max: number) {
-  return z.string().refine(
-    val => {
-      const words = countWords(val)
-      return words >= min && words <= max
-    },
-    {
-      message: `Must be between ${min} and ${max} words`
-    }
-  )
+  return z
+    .string()
+    .describe(JSON.stringify({ minWords: min, maxWords: max }))
+    .refine(
+      val => {
+        const words = countWords(val)
+        return words >= min && words <= max
+      },
+      {
+        message: `Must be between ${min} and ${max} words`
+      }
+    )
 }
 
 // Zod schema for the wizard
-const actionStepSchema = z.object({
+export const actionStepSchema = z.object({
   stepNumber: z.number(),
   "what-did-you-specifically-do-in-this-step": wordRange(20, 150),
   "what-was-the-outcome-of-this-step-optional": wordRange(10, 150)
 })
 
-const starExampleSchema = z.object({
+export const starExampleSchema = z.object({
   situation: z.object({
     "where-and-when-did-this-experience-occur": wordRange(15, 150),
     "briefly-describe-the-situation-or-challenge-you-faced": wordRange(20, 150)

--- a/app/(wizard)/dashboard/new/_components/pitch-wizard/use-wizard.tsx
+++ b/app/(wizard)/dashboard/new/_components/pitch-wizard/use-wizard.tsx
@@ -35,11 +35,11 @@ export function useWizard({
     if (initialStep && Number.isInteger(initialStep) && initialStep > 0) {
       return initialStep
     }
-    
+
     // Check URL search params for step
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       const urlParams = new URLSearchParams(window.location.search)
-      const stepParam = urlParams.get('step')
+      const stepParam = urlParams.get("step")
       if (stepParam) {
         const stepFromUrl = parseInt(stepParam, 10)
         if (!isNaN(stepFromUrl) && stepFromUrl > 0) {
@@ -47,7 +47,7 @@ export function useWizard({
         }
       }
     }
-    
+
     return pitchData?.currentStep || 1
   })
   const [pitchId, setPitchId] = useState<string | undefined>(pitchData?.id)
@@ -196,14 +196,14 @@ export function useWizard({
   // Sync URL with current step - USE SEARCH PARAMS INSTEAD OF ROUTE CHANGES
   useEffect(() => {
     const currentUrl = new URL(window.location.href)
-    const currentStepParam = currentUrl.searchParams.get('step')
-    
+    const currentStepParam = currentUrl.searchParams.get("step")
+
     // Only update URL if step has actually changed
-    if (parseInt(currentStepParam || '1') !== currentStep) {
-      currentUrl.searchParams.set('step', currentStep.toString())
-      
+    if (parseInt(currentStepParam || "1") !== currentStep) {
+      currentUrl.searchParams.set("step", currentStep.toString())
+
       // Use replaceState to avoid server round-trips
-      window.history.replaceState({}, '', currentUrl.toString())
+      window.history.replaceState({}, "", currentUrl.toString())
     }
   }, [currentStep])
 

--- a/app/(wizard)/dashboard/new/_components/result-step.tsx
+++ b/app/(wizard)/dashboard/new/_components/result-step.tsx
@@ -4,7 +4,8 @@
 
 import { useFormContext } from "react-hook-form"
 import { useMemo } from "react"
-import { PitchWizardFormData } from "./pitch-wizard/schema"
+import { PitchWizardFormData, starExampleSchema } from "./pitch-wizard/schema"
+import WordCountIndicator from "./word-count-indicator"
 import {
   FormField,
   FormItem,
@@ -13,11 +14,6 @@ import {
   FormMessage
 } from "@/components/ui/form"
 import { Textarea } from "@/components/ui/textarea"
-
-// Add word count helper
-function countWords(text: string) {
-  return text.trim().split(/\s+/).filter(Boolean).length
-}
 
 interface ResultStepProps {
   /**
@@ -39,8 +35,6 @@ export default function ResultStep({ exampleIndex }: ResultStepProps) {
     watch(
       `starExamples.${exampleIndex}.result.how-did-this-outcome-benefit-your-team-stakeholders-or-organization`
     ) || ""
-
-  const benefitToTeamWords = countWords(benefitToTeam)
 
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-col items-center">
@@ -81,10 +75,15 @@ export default function ResultStep({ exampleIndex }: ResultStepProps) {
                         }}
                       />
                     </FormControl>
+                    <WordCountIndicator
+                      schema={
+                        starExampleSchema.shape.result.shape[
+                          "how-did-this-outcome-benefit-your-team-stakeholders-or-organization"
+                        ]
+                      }
+                      text={benefitToTeam}
+                    />
                     <FormMessage />
-                    <div className="absolute bottom-2 right-3 text-xs text-gray-400">
-                      {benefitToTeamWords}
-                    </div>
                   </div>
                 </FormItem>
               )}

--- a/app/(wizard)/dashboard/new/_components/situation-step.tsx
+++ b/app/(wizard)/dashboard/new/_components/situation-step.tsx
@@ -1,8 +1,10 @@
 "use client"
 
+// Collects information about the Situation portion of a STAR example
 import { useFormContext } from "react-hook-form"
 import { useMemo } from "react"
-import { PitchWizardFormData } from "./pitch-wizard/schema"
+import { PitchWizardFormData, starExampleSchema } from "./pitch-wizard/schema"
+import WordCountIndicator from "./word-count-indicator"
 import {
   FormField,
   FormItem,
@@ -115,11 +117,15 @@ export default function SituationStep({ exampleIndex }: SituationStepProps) {
                         }}
                       />
                     </FormControl>
+                    <WordCountIndicator
+                      schema={
+                        starExampleSchema.shape.situation.shape[
+                          "where-and-when-did-this-experience-occur"
+                        ]
+                      }
+                      text={whereAndWhen}
+                    />
                     <FormMessage />
-                    {/* Word count in bottom-right */}
-                    <div className="absolute bottom-2 right-3 text-xs text-gray-400">
-                      {whereAndWhenWords}
-                    </div>
                   </div>
                 </FormItem>
               )}
@@ -159,11 +165,15 @@ export default function SituationStep({ exampleIndex }: SituationStepProps) {
                         }}
                       />
                     </FormControl>
+                    <WordCountIndicator
+                      schema={
+                        starExampleSchema.shape.situation.shape[
+                          "briefly-describe-the-situation-or-challenge-you-faced"
+                        ]
+                      }
+                      text={situationOrChallenge}
+                    />
                     <FormMessage />
-                    {/* Word count in bottom-right */}
-                    <div className="absolute bottom-2 right-3 text-xs text-gray-400">
-                      {situationOrChallengeWords}
-                    </div>
                   </div>
                 </FormItem>
               )}

--- a/app/(wizard)/dashboard/new/_components/task-step.tsx
+++ b/app/(wizard)/dashboard/new/_components/task-step.tsx
@@ -4,7 +4,8 @@
 
 import { useFormContext } from "react-hook-form"
 import { useMemo } from "react"
-import { PitchWizardFormData } from "./pitch-wizard/schema"
+import { PitchWizardFormData, starExampleSchema } from "./pitch-wizard/schema"
+import WordCountIndicator from "./word-count-indicator"
 import {
   FormField,
   FormItem,
@@ -89,9 +90,14 @@ export default function TaskStep({ exampleIndex }: TaskStepProps) {
                         }}
                       />
                     </FormControl>
-                    <div className="absolute bottom-2 right-3 text-xs text-gray-400">
-                      {responsibilityWords}
-                    </div>
+                    <WordCountIndicator
+                      schema={
+                        starExampleSchema.shape.task.shape[
+                          "what-was-your-responsibility-in-addressing-this-issue"
+                        ]
+                      }
+                      text={responsibility}
+                    />
                   </div>
                 </FormItem>
               )}
@@ -131,9 +137,14 @@ export default function TaskStep({ exampleIndex }: TaskStepProps) {
                         }}
                       />
                     </FormControl>
-                    <div className="absolute bottom-2 right-3 text-xs text-gray-400">
-                      {constraintsWords}
-                    </div>
+                    <WordCountIndicator
+                      schema={
+                        starExampleSchema.shape.task.shape[
+                          "what-constraints-or-requirements-did-you-need-to-consider"
+                        ]
+                      }
+                      text={constraints}
+                    />
                   </div>
                 </FormItem>
               )}

--- a/app/(wizard)/dashboard/new/_components/word-count-indicator.tsx
+++ b/app/(wizard)/dashboard/new/_components/word-count-indicator.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+// Displays a three-dot progress indicator based on word count requirements
+import React from "react"
+import { ZodTypeAny } from "zod"
+
+function countWords(text: string) {
+  return text.trim().split(/\s+/).filter(Boolean).length
+}
+
+function getLimits(schema: ZodTypeAny) {
+  const desc = (schema as any).description
+  if (!desc) return null
+  try {
+    const data = JSON.parse(desc)
+    if (
+      typeof data.minWords === "number" &&
+      typeof data.maxWords === "number"
+    ) {
+      return { min: data.minWords, max: data.maxWords }
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+interface WordCountIndicatorProps {
+  schema: ZodTypeAny
+  text: string
+}
+
+export default function WordCountIndicator({
+  schema,
+  text
+}: WordCountIndicatorProps) {
+  const limits = getLimits(schema)
+  const count = countWords(text)
+
+  if (!limits || count === 0) return null
+
+  const { min, max } = limits
+  const fiftyOver = Math.floor(min * 1.5)
+
+  let active = 0
+  let color = ""
+  let message = ""
+
+  if (count > max) {
+    active = 3
+    color = "bg-green-500"
+    message = "Over limit"
+  } else if (count >= fiftyOver) {
+    active = 3
+    color = "bg-green-500"
+    message = "Excellent!"
+  } else if (count >= min) {
+    active = 2
+    color = "bg-yellow-500"
+    message = "Much better"
+  } else {
+    active = 1
+    color = "bg-red-500"
+    message = "You can do better than this..."
+  }
+
+  return (
+    <div className="mt-1 flex items-center space-x-2 text-xs text-gray-500">
+      <div className="flex space-x-1">
+        {[0, 1, 2].map(i => (
+          <span
+            key={i}
+            className={`size-1.5 rounded-full ${i < active ? color : "bg-gray-300"}`}
+          />
+        ))}
+      </div>
+      <span>{message}</span>
+    </div>
+  )
+}

--- a/app/(wizard)/dashboard/new/page.tsx
+++ b/app/(wizard)/dashboard/new/page.tsx
@@ -40,7 +40,10 @@ export default async function CreateNewPitchPage({
   const initialStep = step ? parseInt(step, 10) : 1
 
   // Validate step number
-  const validStep = !isNaN(initialStep) && initialStep > 0 && initialStep <= 50 ? initialStep : 1
+  const validStep =
+    !isNaN(initialStep) && initialStep > 0 && initialStep <= 50
+      ? initialStep
+      : 1
 
   return (
     <div className="size-full">

--- a/lib/schemas/pitchSchemas.ts
+++ b/lib/schemas/pitchSchemas.ts
@@ -9,10 +9,13 @@ function countWords(text: string) {
 }
 
 function wordRange(min: number, max: number) {
-  return z.string().refine(val => {
-    const words = countWords(val)
-    return words >= min && words <= max
-  }, `Must be between ${min} and ${max} words`)
+  return z
+    .string()
+    .describe(JSON.stringify({ minWords: min, maxWords: max }))
+    .refine(val => {
+      const words = countWords(val)
+      return words >= min && words <= max
+    }, `Must be between ${min} and ${max} words`)
 }
 
 /**


### PR DESCRIPTION
## Summary
- add WordCountIndicator component for STAR fields
- expose word limits via Zod schemas
- show dot progress indicators in Situation, Task, Action and Result steps
- store word ranges in schema metadata for dynamic updates

## Testing
- `npm run lint`
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68495032327c8332a32ecead083d23ff