### PR TITLE
Fix wizard progress initialization

### DIFF
--- a/app/(wizard)/dashboard/new/components/wizard/use-wizard.tsx
+++ b/app/(wizard)/dashboard/new/components/wizard/use-wizard.tsx
@@ -228,7 +228,7 @@ export function useWizard({
       if (targetStep <= currentStep) {
         // Advance UI immediately for better UX
         setCurrentStep(targetStep)
-        
+
         // Save data to database in background (non-blocking)
         setIsSavingInBackground(true)
         savePitchData(
@@ -237,18 +237,20 @@ export function useWizard({
           setPitchId,
           toast,
           targetStep
-        ).catch(error => {
-          console.error("Section navigation save failed:", error)
-          
-          // Show user-friendly error without blocking navigation
-          toast({
-            title: "Save Warning",
-            description: "Your progress will be saved automatically.",
-            variant: "default"
+        )
+          .catch(error => {
+            console.error("Section navigation save failed:", error)
+
+            // Show user-friendly error without blocking navigation
+            toast({
+              title: "Save Warning",
+              description: "Your progress will be saved automatically.",
+              variant: "default"
+            })
           })
-        }).finally(() => {
-          setIsSavingInBackground(false)
-        })
+          .finally(() => {
+            setIsSavingInBackground(false)
+          })
       }
     },
     [
@@ -320,7 +322,7 @@ export function useWizard({
     }
 
     setIsNavigating(true)
-    
+
     try {
       // STEP 1: Fast local validation (blocking) - must pass to proceed
       const isValid = await validateStep(currentStep, starCount, methods)
@@ -331,14 +333,14 @@ export function useWizard({
 
       // STEP 2: Advance UI immediately since validation passed
       setCurrentStep(nextStep)
-      
+
       // STEP 3: Handle special case for moving to pitch generation
       const lastStarStep = 4 + starCount * 4
       if (currentStep === lastStarStep) {
         // Store the form data for pitch generation confirmation
         const formData = methods.getValues()
         pendingFormDataRef.current = formData
-        
+
         // Save data in background before showing confirmation dialog
         setIsSavingInBackground(true)
         savePitchData(formData, pitchId, setPitchId, toast, nextStep)
@@ -361,30 +363,29 @@ export function useWizard({
       savePitchData(formData, pitchId, setPitchId, toast, nextStep)
         .catch(error => {
           console.error("Background save failed:", error)
-          
+
           // Show user-friendly error without blocking their progress
           toast({
             title: "Save Warning",
-            description: "Your progress will be saved automatically. You can continue working.",
+            description:
+              "Your progress will be saved automatically. You can continue working.",
             variant: "default" // Use default instead of destructive to be less alarming
           })
-          
+
           // The auto-save effect will retry the save operation
         })
         .finally(() => {
           setIsSavingInBackground(false)
         })
-
     } catch (error) {
       console.error("Unexpected error in handleNext:", error)
-      
+
       // Handle unexpected validation errors gracefully
       toast({
         title: "Validation Error",
         description: "Please check your inputs and try again.",
         variant: "destructive"
       })
-      
     } finally {
       setIsNavigating(false)
     }

--- a/app/(wizard)/dashboard/new/layout.tsx
+++ b/app/(wizard)/dashboard/new/layout.tsx
@@ -1,7 +1,7 @@
 // app/(wizard)/dashboard/new/layout.tsx
 "use client"
 
-import { useEffect, useState, useRef } from "react"
+import { useLayoutEffect, useState, useRef } from "react"
 import SectionProgressSidebar from "./components/progress/section-progress-bar"
 import MobileProgressHeader from "./components/progress/mobile-progress-header"
 import { Section } from "@/types"
@@ -48,7 +48,7 @@ export default function PitchWizardLayout({
   }
 
   // Listen for section changes from the wizard
-  useEffect(() => {
+  useLayoutEffect(() => {
     const handleSectionChange = (e: any) => {
       if (e.detail && e.detail.section) {
         const newSection = e.detail.section


### PR DESCRIPTION
## Summary
- ensure layout progress listener registers before wizard events by using `useLayoutEffect`
- update formatting in wizard hook via precommit

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_684c309968348332a1a49ef987307e1b