### PR TITLE
Prevent empty pitch save when no edits

### DIFF
--- a/app/(wizard)/dashboard/new/components/wizard/index.tsx
+++ b/app/(wizard)/dashboard/new/components/wizard/index.tsx
@@ -210,10 +210,11 @@ export default function PitchWizard({
               <Button
                 variant="outline"
                 onClick={handleSaveAndClose}
+                disabled={!methods.formState.isDirty}
                 className="group flex items-center px-6 py-3 font-normal text-gray-600 transition-all duration-200 hover:text-gray-800"
               >
                 <Save className="mr-2 size-4 group-hover:scale-110" />
-                Close
+                Save & Close
               </Button>
             )}
 
@@ -273,6 +274,7 @@ export default function PitchWizard({
               <Button
                 variant="outline"
                 onClick={handleSaveAndClose}
+                disabled={!methods.formState.isDirty}
                 className={`group flex items-center justify-center py-3 font-normal text-gray-600 transition-all duration-200 hover:text-gray-800 ${
                   currentStep > 1 && currentStep < totalSteps
                     ? "flex-1"
@@ -280,7 +282,7 @@ export default function PitchWizard({
                 }`}
               >
                 <Save className="mr-2 size-4 group-hover:scale-110" />
-                Close
+                Save & Close
               </Button>
             )}
 

--- a/app/(wizard)/dashboard/new/components/wizard/use-wizard.tsx
+++ b/app/(wizard)/dashboard/new/components/wizard/use-wizard.tsx
@@ -10,7 +10,6 @@ import { savePitchData, triggerFinalPitch, submitFinalPitch } from "./api"
 import { PitchWizardFormData, pitchWizardSchema } from "./schema"
 import { validateStep } from "./validation"
 import {
-  checkIfObjectIsEmpty,
   computeSectionAndHeader,
   firstStepOfSection,
   mapExistingDataToDefaults
@@ -438,14 +437,15 @@ export function useWizard({
 
   // Handler for "Save & Close" button
   const handleSaveAndClose = useCallback(async () => {
-    const data = methods.getValues()
+    const { isDirty } = methods.formState
 
-    // No meaningful data to save
-    if (checkIfObjectIsEmpty(data) || currentStep <= 1) {
+    if (!isDirty) {
       clearCachedPitchId()
       router.push("/dashboard")
       return
     }
+
+    const data = methods.getValues()
 
     try {
       // Await the save to ensure pitchId is set before navigating away

--- a/app/api/guidance/route.ts
+++ b/app/api/guidance/route.ts
@@ -154,7 +154,9 @@ export async function POST(req: NextRequest) {
         // IMPORTANT: clear "in progress" flag when upstream returns error
         try {
           if (requestId) {
-            await updatePitchByExecutionId(requestId, { agentExecutionId: null })
+            await updatePitchByExecutionId(requestId, {
+              agentExecutionId: null
+            })
           }
         } catch (e) {
           console.error(


### PR DESCRIPTION
## Summary
- Guard Save & Close with React Hook Form's `isDirty` to skip saving untouched pitches
- Disable Save & Close buttons until the form has been modified

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a0432ea2448332b8e7d1c91618dd98