### PR TITLE
chore: hide dashboard button in pitch wizard

### DIFF
--- a/app/(wizard)/dashboard/new/layout.tsx
+++ b/app/(wizard)/dashboard/new/layout.tsx
@@ -117,12 +117,14 @@ export default function PitchWizardLayout({
           <div className="flex-1 p-4 pb-20">
             {/* Extra bottom padding for mobile nav */}
             <div className="h-full overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-xl">
+              {/*
               <div className="block px-4 pt-2">
                 <NavigationButton
                   text="Back to Dashboard"
                   className="text-[#444ec1]"
                 />
               </div>
+              */}
 
               <div ref={scrollContainerRef} className="h-full overflow-y-auto">
                 <div className="px-4 pb-4 pt-3 sm:p-6">{children}</div>
@@ -147,12 +149,14 @@ export default function PitchWizardLayout({
 
             {/* Desktop Main content */}
             <div className="flex min-w-0 flex-1 flex-col">
+              {/*
               <div className="ml-10 py-4">
                 <NavigationButton
                   text="Back to Dashboard"
                   className="text-[#444ec1]"
                 />
               </div>
+              */}
 
               <div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
                 <div className="px-8 pb-8 pt-5">{children}</div>


### PR DESCRIPTION
## Summary
- comment out `Back to Dashboard` navigation buttons in the pitch wizard layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a04dbf70d48332915656b765a40eeb