### PR TITLE
fix: keep pitch draft after generation error

### DIFF
--- a/app/(wizard)/dashboard/new/components/steps/guidance-step.tsx
+++ b/app/(wizard)/dashboard/new/components/steps/guidance-step.tsx
@@ -173,7 +173,10 @@ export default function GuidanceStep({
             aria-live="polite"
             style={{ backgroundColor: "#eef2ff", borderColor: "#c7d2fe" }}
           >
-            <div className="mb-2 text-base font-semibold" style={{ color: "#444ec1" }}>
+            <div
+              className="mb-2 text-base font-semibold"
+              style={{ color: "#444ec1" }}
+            >
               Oops! We ran into a hiccup
             </div>
 

--- a/app/(wizard)/dashboard/new/components/steps/review-step.tsx
+++ b/app/(wizard)/dashboard/new/components/steps/review-step.tsx
@@ -245,13 +245,17 @@ export default function ReviewStep({
               aria-live="polite"
               style={{ backgroundColor: "#eef2ff", borderColor: "#c7d2fe" }}
             >
-              <div className="mb-2 text-base font-semibold" style={{ color: "#444ec1" }}>
+              <div
+                className="mb-2 text-base font-semibold"
+                style={{ color: "#444ec1" }}
+              >
                 Oops! We ran into a hiccup
               </div>
 
               <p className="mb-4 text-sm" style={{ color: "#444ec1" }}>
-                It looks like something went wrong while generating your pitch. 
-                This can happen if the service is busy or your internet connection briefly dropped.
+                It looks like something went wrong while generating your pitch.
+                This can happen if the service is busy or your internet
+                connection briefly dropped.
               </p>
 
               <div className="flex justify-center">

--- a/app/(wizard)/dashboard/new/components/wizard/api.ts
+++ b/app/(wizard)/dashboard/new/components/wizard/api.ts
@@ -42,9 +42,10 @@ export async function savePitchData(
   pitchId: string | undefined,
   setPitchId: (id: string) => void,
   toast: ToastFunction,
-  currentStep = 1
+  currentStep = 1,
+  status: "draft" | "final" = "draft"
 ) {
-  const payload = createPitchPayload(data, pitchId, currentStep)
+  const payload = createPitchPayload(data, pitchId, currentStep, status)
 
   debugLog(`[savePitchData] Saving step ${currentStep}`, {
     pitchId,

--- a/app/(wizard)/dashboard/new/components/wizard/use-wizard.tsx
+++ b/app/(wizard)/dashboard/new/components/wizard/use-wizard.tsx
@@ -438,18 +438,23 @@ export function useWizard({
   // Handler for "Save & Close" button
   const handleSaveAndClose = useCallback(async () => {
     const { isDirty } = methods.formState
+    const data = methods.getValues()
 
-    if (!isDirty) {
+    if (!isDirty && !pitchId) {
       clearCachedPitchId()
       router.push("/dashboard")
       return
     }
 
-    const data = methods.getValues()
-
     try {
-      // Await the save to ensure pitchId is set before navigating away
-      await savePitchData(data, pitchId, setPitchId, toast, currentStep)
+      await savePitchData(
+        data,
+        pitchId,
+        setPitchId,
+        toast,
+        currentStep,
+        "draft"
+      )
       clearCachedPitchId()
       router.push("/dashboard")
     } catch (error) {


### PR DESCRIPTION
## Summary
- always persist existing pitch as a draft on save & close
- allow savePitchData to explicitly set pitch status

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a16f2933988332840dace0b701f4b1