### PR TITLE
fix: clear stale pitch id

### DIFF
--- a/app/(wizard)/dashboard/new/components/wizard/use-wizard.tsx
+++ b/app/(wizard)/dashboard/new/components/wizard/use-wizard.tsx
@@ -87,10 +87,12 @@ export function useWizard({
   // Keep track of previous step for animations
   const prevStepRef = useRef(1)
 
-  // Save pitchId to sessionStorage
+  // Save pitchId to sessionStorage, clearing stale values when no pitch
   useEffect(() => {
     if (pitchId) {
       sessionStorage.setItem("ongoingPitchId", pitchId)
+    } else {
+      sessionStorage.removeItem("ongoingPitchId")
     }
   }, [pitchId])
 


### PR DESCRIPTION
## Summary
- Clear `ongoingPitchId` from session storage when no pitch ID exists to prevent unwanted redirects

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a43df122908332a4a31c997cd9ee81