### PR TITLE
feat: refresh job picks calls to action

### DIFF
--- a/app/(marketing)/job-picks/_components/job-picks-with-filters.tsx
+++ b/app/(marketing)/job-picks/_components/job-picks-with-filters.tsx
@@ -1,0 +1,100 @@
+/**
+ * @file app/(marketing)/job-picks/_components/job-picks-with-filters.tsx
+ * @description
+ * Client component that manages global filtering for all job picks and renders
+ * the filtered results grouped by month. The filters are positioned at the top
+ * level for a clean search-like interface.
+ */
+
+"use client"
+
+import * as React from "react"
+import type { SelectJobPick } from "@/types"
+import JobPickFilters from "@/components/job-picks/job-pick-filters"
+import JobPicksSplitBrowser from "@/app/(marketing)/job-picks/_components/job-picks-split-browser"
+
+interface JobPicksWithFiltersProps {
+  picks: SelectJobPick[]
+}
+
+/**
+ * Formats a "YYYY-MM" monthTag to "Month YYYY" (e.g., "2025-08" -> "August 2025").
+ */
+function formatMonthTag(tag: string): string {
+  const [y, m] = tag.split("-").map(Number)
+  const date = new Date(y, (m || 1) - 1, 1)
+  return date.toLocaleDateString("en-AU", { month: "long", year: "numeric" })
+}
+
+/**
+ * Groups job picks by monthTag.
+ */
+function groupByMonthTag(picks: SelectJobPick[]): Record<string, SelectJobPick[]> {
+  return picks.reduce((acc, p) => {
+    const key = p.monthTag
+    if (!acc[key]) acc[key] = []
+    acc[key].push(p)
+    return acc
+  }, {} as Record<string, SelectJobPick[]>)
+}
+
+export default function JobPicksWithFilters({ picks }: JobPicksWithFiltersProps) {
+  const [filteredPicks, setFilteredPicks] = React.useState<SelectJobPick[]>(picks)
+
+  const handleFilterChange = React.useCallback((filtered: SelectJobPick[]) => {
+    setFilteredPicks(filtered)
+  }, [])
+
+  // Update filtered picks when props change
+  React.useEffect(() => {
+    setFilteredPicks(picks)
+  }, [picks])
+
+  const groups = React.useMemo(() => groupByMonthTag(filteredPicks), [filteredPicks])
+  const monthKeys = React.useMemo(() => 
+    Object.keys(groups).sort((a, b) => b.localeCompare(a)), // latest first
+    [groups]
+  )
+
+  const totalVisible = filteredPicks.length
+  const totalOriginal = picks.length
+
+  return (
+    <div className="space-y-8">
+      {/* Global filter bar with search-like styling */}
+      <div className="mx-auto max-w-4xl">
+        <JobPickFilters 
+          picks={picks} 
+          onChange={handleFilterChange}
+          className="shadow-sm"
+        />
+        
+        {/* Results count */}
+        <div className="mt-4 text-center text-muted-foreground text-sm">
+          Showing {totalVisible} of {totalOriginal} role{totalOriginal === 1 ? "" : "s"}
+        </div>
+      </div>
+
+      {/* Filtered results grouped by month */}
+      <div className="space-y-12">
+        {totalVisible === 0 ? (
+          <div className="text-center py-12">
+            <div className="text-muted-foreground rounded-md border p-8 mx-auto max-w-md">
+              No roles match your filters. Try adjusting your search criteria.
+            </div>
+          </div>
+        ) : (
+          monthKeys.map((key) => {
+            const monthPicks = groups[key]
+            return (
+              <div key={key} className="space-y-6">
+                {/* Split-view browser with clickable cards and detail panel */}
+                <JobPicksSplitBrowser picks={monthPicks} />
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+} 

--- a/app/(marketing)/job-picks/page.tsx
+++ b/app/(marketing)/job-picks/page.tsx
@@ -25,6 +25,7 @@ import type { Metadata } from "next"
 import { getPublicJobPicksAction } from "@/actions/db/job-picks-actions"
 import type { SelectJobPick } from "@/types"
 import JobPicksSplitBrowser from "@/app/(marketing)/job-picks/_components/job-picks-split-browser"
+import JobPicksWithFilters from "@/app/(marketing)/job-picks/_components/job-picks-with-filters"
 
 /**
  * ISR: revalidate once per hour to keep listings fresh.
@@ -92,9 +93,6 @@ async function JobPicksFetcher() {
     )
   }
 
-  const groups = groupByMonthTag(picks)
-  const monthKeys = Object.keys(groups).sort((a, b) => b.localeCompare(a)) // latest first
-
   return (
     <div className="container mx-auto py-12">
       <div className="mx-auto mb-8 max-w-3xl text-center">
@@ -105,25 +103,8 @@ async function JobPicksFetcher() {
         </div>
       </div>
 
-      <div className="space-y-12">
-        {monthKeys.map((key) => {
-          const monthPicks = groups[key]
-          return (
-            <div key={key} className="space-y-6">
-              <div className="flex items-center justify-between">
-                <div className="text-2xl font-semibold">{formatMonthTag(key)}</div>
-
-                <div className="text-muted-foreground text-sm">
-                  {monthPicks.length} role{monthPicks.length === 1 ? "" : "s"}
-                </div>
-              </div>
-
-              {/* Split-view browser with clickable cards and detail panel */}
-              <JobPicksSplitBrowser picks={monthPicks} />
-            </div>
-          )
-        })}
-      </div>
+      {/* Global search/filter bar positioned under header */}
+      <JobPicksWithFilters picks={picks} />
     </div>
   )
 }

--- a/app/dashboard/job-picks/[id]/edit/page.tsx
+++ b/app/dashboard/job-picks/[id]/edit/page.tsx
@@ -46,6 +46,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import ClassificationSelect from "../../_components/classification-select"
 import { Save, ArrowLeft, Upload, Archive as ArchiveIcon, Trash2 } from "lucide-react"
+import Link from "next/link"
 
 /**
  * UUID validator for server-side form actions.
@@ -206,10 +207,10 @@ export default async function EditJobPickPage({ params, searchParams }: PageProp
 
         <div>
           <Button variant="outline" asChild>
-            <a href="/dashboard/job-picks">
+            <Link href="/dashboard/job-picks">
               <ArrowLeft className="mr-2 size-4" />
               Back to list
-            </a>
+            </Link>
           </Button>
         </div>
       </div>
@@ -282,10 +283,10 @@ export default async function EditJobPickPage({ params, searchParams }: PageProp
           </form>
 
           <Button variant="outline" asChild>
-            <a href="/dashboard/job-picks">
+            <Link href="/dashboard/job-picks">
               <ArrowLeft className="mr-2 size-4" />
               Back to list
-            </a>
+            </Link>
           </Button>
         </div>
       </div>

--- a/app/dashboard/job-picks/new/page.tsx
+++ b/app/dashboard/job-picks/new/page.tsx
@@ -30,6 +30,7 @@ import { Label } from "@/components/ui/label"
 import ClassificationSelect from "../_components/classification-select"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Save, ArrowLeft } from "lucide-react"
+import Link from "next/link"
 
 interface PageProps {
   searchParams: Promise<{ error?: string }>
@@ -110,10 +111,10 @@ export default async function NewJobPickPage({ searchParams }: PageProps) {
         </div>
 
         <Button variant="outline" asChild>
-          <a href="/dashboard/job-picks">
+          <Link href="/dashboard/job-picks">
             <ArrowLeft className="mr-2 size-4" />
             Back to list
-          </a>
+          </Link>
         </Button>
       </div>
 

--- a/components/job-picks/job-pick-card-compact.tsx
+++ b/components/job-picks/job-pick-card-compact.tsx
@@ -83,7 +83,7 @@ export default function JobPickCardCompact({
                 }}
                 variant="ghost" 
                 size="icon" 
-                className="h-7 w-7"
+                className="size-7"
               />
             </div>
           </div>

--- a/components/job-picks/job-pick-card-compact.tsx
+++ b/components/job-picks/job-pick-card-compact.tsx
@@ -50,24 +50,24 @@ export default function JobPickCardCompact({
   return (
     <Card
       className={cn(
-        "cursor-pointer transition-all duration-200 hover:shadow-md",
-        isSelected ? "border-blue-500 bg-blue-50 shadow-md" : "hover:border-gray-300"
+        "cursor-pointer transition-all duration-200 hover:shadow-sm border-gray-100 bg-white",
+        isSelected ? "border-blue-200 bg-blue-50 shadow-sm ring-1 ring-blue-100" : "hover:border-gray-200 hover:bg-gray-50/50"
       )}
       onClick={onClick}
     >
-      <CardHeader className="pb-2">
+      <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 min-w-0">
-            <h3 className="font-semibold text-sm leading-tight line-clamp-2">
+            <h3 className="font-semibold text-base leading-tight line-clamp-2">
               {title}
             </h3>
-            <div className="flex items-center gap-1 mt-1 text-xs text-muted-foreground">
-              <Building2 className="size-3" />
+            <div className="flex items-center gap-1 mt-2 text-sm text-muted-foreground">
+              <Building2 className="size-4" />
               <span className="truncate">{agency}</span>
             </div>
           </div>
           <div className="flex items-center gap-1 shrink-0">
-            <Badge variant="secondary" className="text-xs">
+            <Badge variant="secondary" className="text-sm px-2 py-1">
               {classification}
             </Badge>
             <div onClick={(e) => e.stopPropagation()}>
@@ -83,7 +83,7 @@ export default function JobPickCardCompact({
                 }}
                 variant="ghost" 
                 size="icon" 
-                className="h-6 w-6"
+                className="h-7 w-7"
               />
             </div>
           </div>
@@ -91,19 +91,19 @@ export default function JobPickCardCompact({
       </CardHeader>
 
       <CardContent className="pt-0">
-        <div className="space-y-1 text-xs text-muted-foreground">
+        <div className="space-y-2 text-sm text-muted-foreground">
           {location && (
             <div className="flex items-center gap-1">
-              <MapPin className="size-3" />
+              <MapPin className="size-4" />
               <span className="truncate">{location}</span>
             </div>
           )}
           <div className="flex items-center gap-1">
-            <CalendarDays className="size-3" />
+            <CalendarDays className="size-4" />
             <span>Closes: {formatCompactDate(closingDate)}</span>
           </div>
           {salary && (
-            <div className="text-xs font-medium text-foreground truncate">
+            <div className="text-sm font-medium text-foreground truncate">
               {salary}
             </div>
           )}

--- a/components/job-picks/job-pick-card.tsx
+++ b/components/job-picks/job-pick-card.tsx
@@ -4,8 +4,8 @@
  * Server component that renders a single curated APS Job Pick in a marketing-friendly card.
  * Shows role title, agency, APS classification, salary, location, closing date, and a short highlight note.
  * Includes two CTAs:
- *  - "View on APS Jobs" (external) with UTM tracking appended.
- *  - "Generate your APS pitch" (internal) linking to the wizard with prefill query params.
+ *  - "Apply on APS Jobs" (external) with UTM tracking appended.
+ *  - "Generate your Pitch" (internal) linking to the wizard with prefill query params.
  *
  * Key features:
  * - Accepts DB-inferred type `SelectJobPick` directly as props for simple spread usage: <JobPickCard {...pick} />
@@ -25,6 +25,7 @@
  */
 
 import Link from "next/link"
+import { auth } from "@clerk/nextjs/server"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -107,7 +108,7 @@ function buildWizardPrefillHref(pick: SelectJobPick): string {
  * JobPickCard component.
  * Accepts the job pick row as the prop object to allow spread usage in maps: <JobPickCard {...pick} />
  */
-export default function JobPickCard(pick: SelectJobPick) {
+export default async function JobPickCard(pick: SelectJobPick) {
   // Prepare external URL with UTM tracking
   const apsHref = withUTM(pick.apsJobsUrl, {
     utm_source: "apspitchpro",
@@ -118,6 +119,10 @@ export default function JobPickCard(pick: SelectJobPick) {
 
   // Internal wizard CTA
   const wizardHref = buildWizardPrefillHref(pick)
+  const { userId } = await auth()
+  const targetHref = userId
+    ? wizardHref
+    : `/login?redirect_url=${encodeURIComponent(wizardHref)}`
 
   return (
     <Card className="h-full overflow-hidden">
@@ -179,7 +184,7 @@ export default function JobPickCard(pick: SelectJobPick) {
 
         {pick.highlightNote && (
           <div className="rounded-md border p-3 text-sm">
-            <div className="text-muted-foreground mb-1">Why this role</div>
+            <div className="text-muted-foreground mb-1">About this role</div>
             <div>{pick.highlightNote}</div>
           </div>
         )}
@@ -192,17 +197,17 @@ export default function JobPickCard(pick: SelectJobPick) {
             href={apsHref}
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="View role on APS Jobs"
+            aria-label="Apply on APS Jobs"
           >
             <ExternalLink className="mr-2 size-4" />
-            View on APS Jobs
+            Apply on APS Jobs
           </a>
         </Button>
 
         <Button asChild className="w-full sm:w-auto">
-          <Link href={wizardHref} aria-label="Generate your APS pitch for this role">
+          <Link href={targetHref} aria-label="Generate your pitch for this role">
             <Wand2 className="mr-2 size-4" />
-            Generate your APS pitch
+            Generate your Pitch
           </Link>
         </Button>
       </CardFooter>

--- a/components/job-picks/job-pick-card.tsx
+++ b/components/job-picks/job-pick-card.tsx
@@ -60,48 +60,16 @@ function formatAUSDate(date?: Date | string | null): string {
 }
 
 /**
- * Appends or sets UTM parameters on a URL string.
- * Falls back to the original URL when parsing fails.
- * @param href Original URL
- * @param utm Record of utm fields
+ * Safely appends UTM parameters to a URL.
  */
 function withUTM(href: string, utm: Record<string, string>): string {
   try {
     const url = new URL(href)
-    Object.entries(utm).forEach(([k, v]) => url.searchParams.set(k, v))
+    Object.entries(utm).forEach(([key, value]) => url.searchParams.set(key, value))
     return url.toString()
   } catch {
     return href
   }
-}
-
-/**
- * Allowed role levels for prefill. The wizard's schema currently validates to these values.
- */
-const ALLOWED_ROLE_LEVELS = new Set([
-  "APS1",
-  "APS2",
-  "APS3",
-  "APS4",
-  "APS5",
-  "APS6",
-  "EL1"
-])
-
-/**
- * Builds the internal wizard prefill URL with safe query parameters.
- * - Always includes `source=job-picks`.
- * - Includes roleLevel only if classification matches the allowed set.
- */
-function buildWizardPrefillHref(pick: SelectJobPick): string {
-  const params = new URLSearchParams()
-  params.set("source", "job-picks")
-  if (pick.title?.trim()) params.set("roleName", pick.title)
-  if (pick.agency?.trim()) params.set("organisationName", pick.agency)
-  if (ALLOWED_ROLE_LEVELS.has(pick.classification)) {
-    params.set("roleLevel", pick.classification)
-  }
-  return `/dashboard/new?${params.toString()}`
 }
 
 /**
@@ -117,12 +85,11 @@ export default async function JobPickCard(pick: SelectJobPick) {
     utm_content: pick.title || "role"
   })
 
-  // Internal wizard CTA
-  const wizardHref = buildWizardPrefillHref(pick)
+  // Internal dashboard CTA (changed from wizard)
   const { userId } = await auth()
   const targetHref = userId
-    ? wizardHref
-    : `/login?redirect_url=${encodeURIComponent(wizardHref)}`
+    ? "/dashboard"
+    : `/login?redirect_url=${encodeURIComponent("/dashboard")}`
 
   return (
     <Card className="h-full overflow-hidden">

--- a/components/job-picks/job-pick-detail-view.tsx
+++ b/components/job-picks/job-pick-detail-view.tsx
@@ -35,37 +35,16 @@ function formatAUSDate(date?: Date | string | null): string {
 }
 
 /**
- * Appends or sets UTM parameters on a URL string.
+ * Safely appends UTM parameters to a URL.
  */
 function withUTM(href: string, utm: Record<string, string>): string {
   try {
     const url = new URL(href)
-    Object.entries(utm).forEach(([k, v]) => url.searchParams.set(k, v))
+    Object.entries(utm).forEach(([key, value]) => url.searchParams.set(key, value))
     return url.toString()
   } catch {
     return href
   }
-}
-
-/**
- * Allowed role levels for prefill.
- */
-const ALLOWED_ROLE_LEVELS = new Set([
-  "APS1", "APS2", "APS3", "APS4", "APS5", "APS6", "EL1"
-])
-
-/**
- * Builds the internal wizard prefill URL with safe query parameters.
- */
-function buildWizardPrefillHref(pick: SelectJobPick): string {
-  const params = new URLSearchParams()
-  params.set("source", "job-picks")
-  if (pick.title?.trim()) params.set("roleName", pick.title)
-  if (pick.agency?.trim()) params.set("organisationName", pick.agency)
-  if (ALLOWED_ROLE_LEVELS.has(pick.classification)) {
-    params.set("roleLevel", pick.classification)
-  }
-  return `/dashboard/new?${params.toString()}`
 }
 
 interface JobPickDetailViewProps {
@@ -99,12 +78,11 @@ export default function JobPickDetailView({ job }: JobPickDetailViewProps) {
     utm_content: job.title || "role"
   })
 
-  // Internal wizard CTA
-  const wizardHref = buildWizardPrefillHref(job)
+  // Internal dashboard CTA (changed from wizard)
   const handleGenerate = () => {
     const href = userId
-      ? wizardHref
-      : `/login?redirect_url=${encodeURIComponent(wizardHref)}`
+      ? "/dashboard"
+      : `/login?redirect_url=${encodeURIComponent("/dashboard")}`
     router.push(href)
   }
 

--- a/components/job-picks/job-pick-detail-view.tsx
+++ b/components/job-picks/job-pick-detail-view.tsx
@@ -7,7 +7,8 @@
 
 "use client"
 
-import Link from "next/link"
+import { useAuth } from "@clerk/nextjs"
+import { useRouter } from "next/navigation"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -72,14 +73,17 @@ interface JobPickDetailViewProps {
 }
 
 export default function JobPickDetailView({ job }: JobPickDetailViewProps) {
+  const router = useRouter()
+  const { userId } = useAuth()
+
   if (!job) {
     return (
       <div className="flex h-full items-center justify-center p-8 text-center">
         <div className="space-y-3">
-          <div className="text-lg font-medium text-muted-foreground">
+          <div className="text-muted-foreground text-lg font-medium">
             Select a job to view details
           </div>
-          <div className="text-sm text-muted-foreground">
+          <div className="text-muted-foreground text-sm">
             Click on any job card from the left to see the full details here
           </div>
         </div>
@@ -97,16 +101,22 @@ export default function JobPickDetailView({ job }: JobPickDetailViewProps) {
 
   // Internal wizard CTA
   const wizardHref = buildWizardPrefillHref(job)
+  const handleGenerate = () => {
+    const href = userId
+      ? wizardHref
+      : `/login?redirect_url=${encodeURIComponent(wizardHref)}`
+    router.push(href)
+  }
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="p-6 space-y-6">
+      <div className="space-y-6 p-6">
         {/* Header */}
         <div className="space-y-4">
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-2">
               <h1 className="text-2xl font-bold leading-tight">{job.title}</h1>
-              <div className="flex items-center gap-2 text-muted-foreground">
+              <div className="text-muted-foreground flex items-center gap-2">
                 <Building2 className="size-4" />
                 <span className="text-lg">{job.agency}</span>
               </div>
@@ -120,12 +130,12 @@ export default function JobPickDetailView({ job }: JobPickDetailViewProps) {
           <div className="flex flex-wrap gap-4 text-sm">
             {job.location && (
               <div className="flex items-center gap-1">
-                <MapPin className="size-4 text-muted-foreground" />
+                <MapPin className="text-muted-foreground size-4" />
                 <span>{job.location}</span>
               </div>
             )}
             <div className="flex items-center gap-1">
-              <Clock className="size-4 text-muted-foreground" />
+              <Clock className="text-muted-foreground size-4" />
               <span>Full-time</span>
             </div>
           </div>
@@ -133,21 +143,19 @@ export default function JobPickDetailView({ job }: JobPickDetailViewProps) {
 
         {/* Action buttons */}
         <div className="flex flex-col gap-3 sm:flex-row">
-          <Button asChild size="lg" className="flex-1">
-            <Link href={wizardHref} aria-label="Generate your APS pitch for this role">
-              <Wand2 className="mr-2 size-4" />
-              Generate your APS pitch
-            </Link>
+          <Button onClick={handleGenerate} size="lg" className="flex-1">
+            <Wand2 className="mr-2 size-4" />
+            Generate your Pitch
           </Button>
           <Button asChild variant="outline" size="lg" className="flex-1">
             <a
               href={apsHref}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="View role on APS Jobs"
+              aria-label="Apply on APS Jobs"
             >
               <ExternalLink className="mr-2 size-4" />
-              View on APS Jobs
+              Apply on APS Jobs
             </a>
           </Button>
         </div>
@@ -164,7 +172,7 @@ export default function JobPickDetailView({ job }: JobPickDetailViewProps) {
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="space-y-1">
                   <div className="flex items-center gap-2">
-                    <DollarSign className="size-4 text-muted-foreground" />
+                    <DollarSign className="text-muted-foreground size-4" />
                     <span className="font-medium">Salary</span>
                   </div>
                   <div className="text-lg font-semibold">
@@ -174,7 +182,7 @@ export default function JobPickDetailView({ job }: JobPickDetailViewProps) {
 
                 <div className="space-y-1">
                   <div className="flex items-center gap-2">
-                    <CalendarDays className="size-4 text-muted-foreground" />
+                    <CalendarDays className="text-muted-foreground size-4" />
                     <span className="font-medium">Closing Date</span>
                   </div>
                   <div className="text-lg font-semibold">
@@ -184,17 +192,24 @@ export default function JobPickDetailView({ job }: JobPickDetailViewProps) {
 
                 <div className="space-y-1">
                   <div className="flex items-center gap-2">
-                    <MapPin className="size-4 text-muted-foreground" />
+                    <MapPin className="text-muted-foreground size-4" />
                     <span className="font-medium">Location</span>
                   </div>
                   <div className="text-lg font-semibold">
                     {job.location || "Not specified"}
                   </div>
                 </div>
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <Clock className="text-muted-foreground size-4" />
+                    <span className="font-medium">Job Type</span>
+                  </div>
+                  <div className="text-lg font-semibold">Full-time</div>
+                </div>
 
                 <div className="space-y-1">
                   <div className="flex items-center gap-2">
-                    <Building2 className="size-4 text-muted-foreground" />
+                    <Building2 className="text-muted-foreground size-4" />
                     <span className="font-medium">Classification</span>
                   </div>
                   <div className="text-lg font-semibold">
@@ -209,7 +224,7 @@ export default function JobPickDetailView({ job }: JobPickDetailViewProps) {
           {job.highlightNote && (
             <Card>
               <CardHeader>
-                <CardTitle className="text-lg">Why this role?</CardTitle>
+                <CardTitle className="text-lg">About this role</CardTitle>
                 <CardDescription>
                   Our expert insights on what makes this role special
                 </CardDescription>
@@ -221,23 +236,6 @@ export default function JobPickDetailView({ job }: JobPickDetailViewProps) {
               </CardContent>
             </Card>
           )}
-
-          {/* Additional info */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Additional Information</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <div className="flex justify-between items-center">
-                <span className="text-sm font-medium">Month Tag</span>
-                <Badge variant="outline">{job.monthTag}</Badge>
-              </div>
-              <div className="flex justify-between items-center">
-                <span className="text-sm font-medium">Job Type</span>
-                <span className="text-sm">Full-time</span>
-              </div>
-            </CardContent>
-          </Card>
         </div>
       </div>
     </div>

--- a/components/job-picks/job-pick-filters.tsx
+++ b/components/job-picks/job-pick-filters.tsx
@@ -127,7 +127,7 @@ export default function JobPickFilters({
         {/* Text Search */}
         <div className="flex-1 max-w-sm">
           <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 size-4 text-gray-400" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-gray-400" />
             <Input
               type="text"
               value={searchText}


### PR DESCRIPTION
## Summary
- require authentication before generating a pitch from job picks and rename CTA
- relabel APS link as "Apply" and move Job Type into Job Details
- rename "Why this role" sections to "About this role"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Do not use an `<a>` element to navigate to `/dashboard/job-picks/`...)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b138c2adfc83328ee3abe096b602dd