### PR TITLE
Trigger AI guidance on step transition

### DIFF
--- a/app/(wizard)/dashboard/new/components/wizard/index.tsx
+++ b/app/(wizard)/dashboard/new/components/wizard/index.tsx
@@ -66,14 +66,16 @@ export default function PitchWizard({
     retryPitchGeneration,
     // Feedback dialog control
     showFeedbackDialog,
-    setShowFeedbackDialog
+    setShowFeedbackDialog,
+    aiGuidance
   } = useWizard({ userId, pitchData, initialStep })
 
   function renderStep() {
     if (currentStep === 1) return <WizardIntroStep />
     if (currentStep === 2) return <RoleStep />
     if (currentStep === 3) return <ExperienceStep />
-    if (currentStep === 4) return <GuidanceStep pitchId={pitchId} />
+    if (currentStep === 4)
+      return <GuidanceStep pitchId={pitchId} aiGuidance={aiGuidance} />
     if (currentStep === 5) return <StarExamplesIntroStep />
 
     const firstActualStarStep = 6


### PR DESCRIPTION
## Summary
- Fetch AI guidance when advancing from the Experience step instead of on Guidance step mount
- Provide guidance state via props to GuidanceStep for rendering and retries
- Wire wizard to pass guidance hook and handle request initiation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c00fb0d8d083328ea7cc64f4de1dbe