### PR TITLE
Fix wizard navigation race conditions and jarring URL redirects

### DIFF
--- a/app/(wizard)/dashboard/new/components/utilities/check-stored-pitch.tsx
+++ b/app/(wizard)/dashboard/new/components/utilities/check-stored-pitch.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect } from "react"
-import { useRouter, useSearchParams } from "next/navigation"
+import { useRouter, useSearchParams, usePathname } from "next/navigation"
 
 export default function CheckStoredPitch({
   onReady
@@ -10,6 +10,7 @@ export default function CheckStoredPitch({
 }) {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const pathname = usePathname()
 
   useEffect(() => {
     const isNewPitch = searchParams.get("new") === "true"
@@ -39,16 +40,13 @@ export default function CheckStoredPitch({
       }
     } else {
       // Redirect to clean /new only if not already there
-      if (
-        window.location.pathname + window.location.search !==
-        "/dashboard/new"
-      ) {
+      if (pathname !== "/dashboard/new") {
         router.replace("/dashboard/new")
       } else {
         onReady?.()
       }
     }
-  }, [router, searchParams, onReady])
+  }, [router, searchParams, onReady, pathname])
 
   return null
 }


### PR DESCRIPTION
- Fix CheckStoredPitch to use pathname instead of full URL to prevent erroneous redirects when step query parameters are present
- Implement synchronous saving in handleNext to ensure pitch is created before step advancement, eliminating race conditions
- Add immediate sessionStorage update after pitch creation
- Implement smart redirect logic that only redirects for new pitch creation (step 2→3) while using normal navigation for existing pitch updates
- Prevent jarring flash effect by redirecting directly to correct URL instead of advancing step then redirecting

Resolves issues where:
1. URL initially showed /new?step=4 then redirected to /new/<pitchId>?step=4
2. Page would flash/jump due to step advancing before URL redirect
3. Navigation would get stuck after step 3 due to router conflicts