### PR TITLE
Ensure dashboard sidebar auto-creates profile

### DIFF
--- a/app/dashboard/_components/dashboard-sidebar.tsx
+++ b/app/dashboard/_components/dashboard-sidebar.tsx
@@ -13,7 +13,7 @@
 
 import Link from "next/link"
 import { Settings, CreditCard, Newspaper } from "lucide-react"
-import { getProfileByUserIdAction } from "@/actions/db/profiles-actions"
+import { ensureProfileAction } from "@/actions/db/profiles-actions"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
@@ -37,10 +37,11 @@ export default async function DashboardSidebar({
   userId
 }: DashboardSidebarProps) {
   // Credits
-  const profileResult = await getProfileByUserIdAction(userId)
-  const credits = profileResult.isSuccess
-    ? (profileResult.data?.credits ?? 0)
-    : 0
+  const profileResult = await ensureProfileAction(userId)
+  const credits =
+    profileResult.isSuccess && profileResult.data
+      ? profileResult.data.credits
+      : 0
 
   // Admin check for conditional links
   const admin = await isAdmin()


### PR DESCRIPTION
## Summary
- call `ensureProfileAction` when loading the dashboard sidebar
- guarantee new users immediately see their starter credits without refreshing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0cf841b9c83329d5acd62fc9842ba