### PR TITLE
Ensure new users see initial credits immediately

### DIFF
--- a/app/dashboard/_components/dashboard-sidebar.tsx
+++ b/app/dashboard/_components/dashboard-sidebar.tsx
@@ -13,7 +13,7 @@
 
 import Link from "next/link"
 import { Settings, CreditCard, Newspaper } from "lucide-react"
-import { getProfileByUserIdAction } from "@/actions/db/profiles-actions"
+import { ensureProfileAction } from "@/actions/db/profiles-actions"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
@@ -37,7 +37,7 @@ export default async function DashboardSidebar({
   userId
 }: DashboardSidebarProps) {
   // Credits
-  const profileResult = await getProfileByUserIdAction(userId)
+  const profileResult = await ensureProfileAction(userId)
   const credits = profileResult.isSuccess
     ? (profileResult.data?.credits ?? 0)
     : 0


### PR DESCRIPTION
## Summary
- ensure the profile action creates a record when missing and retries after race conditions
- switch the dashboard sidebar to call the ensure action so first-time users immediately see their starter credits

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0cf841b9c83329d5acd62fc9842ba