### PR TITLE
Fix pitch wizard responsive layout state duplication

### DIFF
--- a/app/(wizard)/dashboard/new/layout.tsx
+++ b/app/(wizard)/dashboard/new/layout.tsx
@@ -110,56 +110,34 @@ export default function PitchWizardLayout({
         </div>
       </header>
 
-      {/* Main container - Mobile and Desktop layouts */}
-      <div className="flex flex-1">
-        {/* Mobile Layout - Stacked */}
-        <div className="flex flex-1 flex-col lg:hidden">
-          <div className="flex-1 p-4 pb-20">
-            {/* Extra bottom padding for mobile nav */}
-            <div className="h-full overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-xl">
-              {/*
-              <div className="block px-4 pt-2">
-                <NavigationButton
-                  text="Back to Dashboard"
-                  className="text-[#444ec1]"
-                />
-              </div>
-              */}
-
-              <div ref={scrollContainerRef} className="h-full overflow-y-auto">
-                <div className="px-4 pb-4 pt-3 sm:p-6">{children}</div>
-              </div>
+      {/* Main container - Responsive layout */}
+      <div className="flex flex-1 flex-col p-4 pb-20 lg:items-center lg:justify-center lg:p-6">
+        <div className="mx-auto flex size-full flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-xl lg:h-[calc(100vh-140px)] lg:w-[90%] lg:max-w-6xl lg:flex-row lg:rounded-3xl lg:shadow-2xl">
+          {/* Desktop Sidebar */}
+          <div className="hidden w-72 shrink-0 border-r border-gray-100 bg-white shadow-lg lg:flex">
+            <div className="h-full overflow-y-auto p-8">
+              <SectionProgressSidebar
+                current={currentSection}
+                maxCompleted={maxCompletedSection}
+                onNavigate={handleSectionNavigate}
+              />
             </div>
           </div>
-        </div>
 
-        {/* Desktop Layout - Sidebar + Content */}
-        <div className="hidden flex-1 items-center justify-center p-6 lg:flex">
-          <div className="flex h-[calc(100vh-140px)] w-[90%] max-w-6xl overflow-hidden rounded-3xl border border-gray-100 bg-white shadow-2xl">
-            {/* Desktop Sidebar */}
-            <div className="w-72 shrink-0 border-r border-gray-100 bg-white shadow-lg">
-              <div className="h-full overflow-y-auto p-8">
-                <SectionProgressSidebar
-                  current={currentSection}
-                  maxCompleted={maxCompletedSection}
-                  onNavigate={handleSectionNavigate}
-                />
-              </div>
+          {/* Wizard content */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            {/*
+            <div className="ml-10 py-4">
+              <NavigationButton
+                text="Back to Dashboard"
+                className="text-[#444ec1]"
+              />
             </div>
+            */}
 
-            {/* Desktop Main content */}
-            <div className="flex min-w-0 flex-1 flex-col">
-              {/*
-              <div className="ml-10 py-4">
-                <NavigationButton
-                  text="Back to Dashboard"
-                  className="text-[#444ec1]"
-                />
-              </div>
-              */}
-
-              <div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
-                <div className="px-8 pb-8 pt-5">{children}</div>
+            <div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
+              <div className="px-4 pb-4 pt-3 sm:p-6 lg:px-8 lg:pb-8 lg:pt-5">
+                {children}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- render the pitch wizard content once so desktop and mobile share the same state
- consolidate responsive container styling while keeping the desktop sidebar and mobile padding

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0ebd868488332812cc0328ba9a614